### PR TITLE
Fix body encoding to utf-8 for POST requests

### DIFF
--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -485,6 +485,7 @@ public class KillBillHttpClient {
         }
 
         builder.addHeader("Content-Type", "application/json; charset=utf-8");
+        builder.setBodyEncoding("UTF-8");
 
         for (final String key : options.keySet()) {
             if (options.get(key) != null) {


### PR DESCRIPTION
Without this line, account creation fails when any of the account fields contains a non-ascii character (in my case character è), because the KillBill server expects utf-8. 

Without the line, the http client uses ISO-8859-1 by default for the body encoding (line 794 of NettyAsyncHttpProvider.java).
