### PR TITLE
Handles KB HTTP Response Errors

### DIFF
--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -61,7 +61,7 @@ public class KillBillHttpClient {
 
     public static final int DEFAULT_HTTP_TIMEOUT_SEC = 10;
 
-    public static final Multimap<String, String> DEFAULT_EMPTY_QUERY = ImmutableMultimap.<String, String>of();
+    public static final Multimap<String, String> DEFAULT_EMPTY_QUERY = ImmutableMultimap.of();
     public static final String AUDIT_OPTION_CREATED_BY = "__AUDIT_OPTION_CREATED_BY";
     public static final String AUDIT_OPTION_REASON = "__AUDIT_OPTION_REASON";
     public static final String AUDIT_OPTION_COMMENT = "__AUDIT_OPTION_COMMENT";
@@ -327,7 +327,7 @@ public class KillBillHttpClient {
     }
 
     private <T> T doPrepareRequestAndMaybeFollowLocation(final String verb, final String uri, final Object body, final Multimap<String, String> optionsRo, final Multimap<String, String> optionsForFollow, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
-        final Multimap<String, String> options = HashMultimap.<String, String>create(optionsRo);
+        final Multimap<String, String> options = HashMultimap.create(optionsRo);
 
         final String createdBy = getUniqueValue(options, AUDIT_OPTION_CREATED_BY);
         final String reason = getUniqueValue(options, AUDIT_OPTION_REASON);
@@ -409,7 +409,7 @@ public class KillBillHttpClient {
 
     private String getUniqueValue(final Multimap<String, String> options, final String key) {
         final Collection<String> values = options.get(key);
-        if (values == null || values.size() == 0) {
+        if (values == null || values.isEmpty()) {
             return null;
         } else {
             Preconditions.checkState(values.size() == 1, "You can only specify a unique value for " + key);
@@ -587,7 +587,7 @@ public class KillBillHttpClient {
             } else {
                 return String.format("%s%s", kbServerUrl, uri);
             }
-        } catch (URISyntaxException e) {
+        } catch (final URISyntaxException e) {
             throw new KillBillClientException(e);
         }
     }

--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -61,7 +61,7 @@ public class KillBillHttpClient {
 
     public static final int DEFAULT_HTTP_TIMEOUT_SEC = 10;
 
-    public static final Multimap<String, String> DEFAULT_EMPTY_QUERY = ImmutableMultimap.of();
+    public static final Multimap<String, String> DEFAULT_EMPTY_QUERY = ImmutableMultimap.<String, String>of();
     public static final String AUDIT_OPTION_CREATED_BY = "__AUDIT_OPTION_CREATED_BY";
     public static final String AUDIT_OPTION_REASON = "__AUDIT_OPTION_REASON";
     public static final String AUDIT_OPTION_COMMENT = "__AUDIT_OPTION_COMMENT";
@@ -325,7 +325,7 @@ public class KillBillHttpClient {
     }
 
     private <T> T doPrepareRequestAndMaybeFollowLocation(final String verb, final String uri, final Object body, final Multimap<String, String> optionsRo, final Multimap<String, String> optionsForFollow, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
-        final Multimap<String, String> options = HashMultimap.create(optionsRo);
+        final Multimap<String, String> options = HashMultimap.<String, String>create(optionsRo);
 
         final String createdBy = getUniqueValue(options, AUDIT_OPTION_CREATED_BY);
         final String reason = getUniqueValue(options, AUDIT_OPTION_REASON);

--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -75,6 +75,8 @@ public class KillBillHttpClient {
     public static final String HTTP_HEADER_ACCEPT = "Accept";
     public static final String HTTP_HEADER_CONTENT_TYPE = "Content-Type";
 
+    public static final int HTTP_PAYMENT_REQUIRED_STATUS = 402;
+
     public static final String ACCEPT_HTML = "text/html";
     public static final String ACCEPT_JSON = "application/json";
     public static final String ACCEPT_XML = "application/xml";
@@ -457,7 +459,8 @@ public class KillBillHttpClient {
             } else {
                 return null;
             }
-        } else if (response != null && response.getStatusCode() >= 400) {
+        } else if (response != null && response.getStatusCode() >= 400
+                   && response.getStatusCode() != HTTP_PAYMENT_REQUIRED_STATUS) {
             final BillingException exception = deserializeResponse(response, BillingException.class);
             log.warn("Error " + response.getStatusCode() + " from Kill Bill: " + exception.getMessage());
             throw new KillBillClientException(exception, response);


### PR DESCRIPTION
WIP - Make sure we treat 402 similarly to how we handle 201, by following the location and retrieving the payment

Should we handle other errors similarly? 502, 503, 504?

Or maybe we could throw an exception for each case, having the payment as a attribute of the exception.