### PR TITLE
Request Options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>1.57</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/killbill/billing/client/JaxrsResource.java
+++ b/src/main/java/org/killbill/billing/client/JaxrsResource.java
@@ -103,6 +103,7 @@ public interface JaxrsResource {
     public static final String HDR_PAGINATION_TOTAL_NB_RECORDS = "X-Killbill-Pagination-TotalNbRecords";
     public static final String HDR_PAGINATION_MAX_NB_RECORDS = "X-Killbill-Pagination-MaxNbRecords";
     public static final String HDR_PAGINATION_NEXT_PAGE_URI = "X-Killbill-Pagination-NextPageUri";
+    public static final String HDR_REQUEST_ID = "X-Request-Id";
 
     /*
      * Query parameters

--- a/src/main/java/org/killbill/billing/client/KillBillClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillClient.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.client;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -106,7 +107,7 @@ import static org.killbill.billing.client.KillBillHttpClient.CONTENT_TYPE_XML;
 import static org.killbill.billing.client.KillBillHttpClient.DEFAULT_EMPTY_QUERY;
 import static org.killbill.billing.client.KillBillHttpClient.DEFAULT_HTTP_TIMEOUT_SEC;
 
-public class KillBillClient {
+public class KillBillClient implements Closeable {
 
     private final KillBillHttpClient httpClient;
 
@@ -118,6 +119,7 @@ public class KillBillClient {
         this.httpClient = httpClient;
     }
 
+    @Override
     public void close() {
         httpClient.close();
     }
@@ -949,6 +951,26 @@ public class KillBillClient {
         return httpClient.doGet(uri, queryParams, Payments.class);
     }
 
+    @Deprecated
+    public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return this.createPayment(comboPaymentTransaction, pluginProperties, RequestOptions.builder()
+                                                                                           .withCreatedBy(createdBy)
+                                                                                           .withReason(reason)
+                                                                                           .withComment(comment).build());
+    }
+
+    public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
+        return this.createPayment(comboPaymentTransaction, null, pluginProperties, inputOptions);
+    }
+
+    @Deprecated
+    public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return createPayment(comboPaymentTransaction, controlPluginNames, pluginProperties, RequestOptions.builder()
+                                                                                                          .withCreatedBy(createdBy)
+                                                                                                          .withReason(reason)
+                                                                                                          .withComment(comment).build());
+    }
+
     public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         final String uri = JaxrsResource.PAYMENTS_PATH + "/" + JaxrsResource.COMBO;
 
@@ -965,35 +987,53 @@ public class KillBillClient {
         return httpClient.doPost(uri, comboPaymentTransaction, Payment.class, requestOptions);
     }
 
-    public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        final RequestOptions requestOptions = RequestOptions.builder()
-                                                            .withCreatedBy(createdBy)
-                                                            .withReason(reason)
-                                                            .withComment(comment).build();
-
-        return createPayment(comboPaymentTransaction, controlPluginNames, pluginProperties, requestOptions);
-    }
-
-    public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return this.createPayment(comboPaymentTransaction, null, pluginProperties, createdBy, reason, comment);
-    }
-
-
+    @Deprecated
     public Payment createPayment(final UUID accountId, final PaymentTransaction paymentTransaction, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return createPayment(accountId, paymentTransaction, ImmutableMap.<String, String>of(), createdBy, reason, comment);
+        return createPayment(accountId, paymentTransaction, RequestOptions.builder()
+                                                                          .withCreatedBy(createdBy)
+                                                                          .withReason(reason)
+                                                                          .withComment(comment).build());
     }
 
+    public Payment createPayment(final UUID accountId, final PaymentTransaction paymentTransaction, final RequestOptions inputOptions) throws KillBillClientException {
+        return createPayment(accountId, null, paymentTransaction, null, ImmutableMap.<String, String>of(), inputOptions);
+    }
+
+    @Deprecated
     public Payment createPayment(final UUID accountId, final PaymentTransaction paymentTransaction, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return createPayment(accountId, null, paymentTransaction, pluginProperties, createdBy, reason, comment);
+        return createPayment(accountId, paymentTransaction, pluginProperties, RequestOptions.builder()
+                                                                                            .withCreatedBy(createdBy)
+                                                                                            .withReason(reason)
+                                                                                            .withComment(comment).build());
     }
 
+    public Payment createPayment(final UUID accountId, final PaymentTransaction paymentTransaction, final Map<String, String> pluginProperties, RequestOptions inputOptions) throws KillBillClientException {
+        return createPayment(accountId, null, paymentTransaction, null, pluginProperties, inputOptions);
+    }
+
+    @Deprecated
     public Payment createPayment(final UUID accountId, @Nullable final UUID paymentMethodId, final PaymentTransaction paymentTransaction, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return createPayment(accountId, paymentMethodId, paymentTransaction, ImmutableMap.<String, String>of(), createdBy, reason, comment);
+        return createPayment(accountId, paymentMethodId, paymentTransaction, RequestOptions.builder()
+                                                                                           .withCreatedBy(createdBy)
+                                                                                           .withReason(reason)
+                                                                                           .withComment(comment).build());
     }
 
+    public Payment createPayment(final UUID accountId, @Nullable final UUID paymentMethodId, final PaymentTransaction paymentTransaction, final RequestOptions inputOptions) throws KillBillClientException {
+        return createPayment(accountId, paymentMethodId, paymentTransaction, null, ImmutableMap.<String, String>of(), inputOptions);
+    }
+
+    @Deprecated
     public Payment createPayment(final UUID accountId, @Nullable final UUID paymentMethodId, final PaymentTransaction paymentTransaction, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return createPayment(accountId, paymentMethodId, paymentTransaction, null, pluginProperties,
-                             RequestOptions.builder().withCreatedBy(createdBy).withReason(reason).withComment(comment).build());
+        return createPayment(accountId, paymentMethodId, paymentTransaction, pluginProperties, RequestOptions.builder()
+                                                                                                             .withCreatedBy(createdBy)
+                                                                                                             .withReason(reason)
+                                                                                                             .withComment(comment)
+                                                                                                             .build());
+    }
+
+    public Payment createPayment(final UUID accountId, @Nullable final UUID paymentMethodId, final PaymentTransaction paymentTransaction, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
+        return createPayment(accountId, paymentMethodId, paymentTransaction, null, pluginProperties, inputOptions);
     }
 
     public Payment createPayment(final UUID accountId, @Nullable final UUID paymentMethodId, final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
@@ -1025,33 +1065,68 @@ public class KillBillClient {
         return httpClient.doPost(uri, paymentTransaction, Payment.class, requestOptions);
     }
 
+    @Deprecated
     public Payment completePayment(final PaymentTransaction paymentTransaction, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return completePayment(paymentTransaction, ImmutableMap.<String, String>of(), createdBy, reason, comment);
+        return completePayment(paymentTransaction, RequestOptions.builder()
+                                                                 .withCreatedBy(createdBy)
+                                                                 .withReason(reason)
+                                                                 .withComment(comment)
+                                                                 .build());
     }
 
+    public Payment completePayment(final PaymentTransaction paymentTransaction, final RequestOptions requestOptions) throws KillBillClientException {
+        return completePayment(paymentTransaction, ImmutableMap.<String, String>of(), requestOptions);
+    }
+
+    @Deprecated
     public Payment completePayment(final PaymentTransaction paymentTransaction, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return completePayment(paymentTransaction, pluginProperties, RequestOptions.builder()
+                                                                                   .withCreatedBy(createdBy)
+                                                                                   .withReason(reason)
+                                                                                   .withComment(comment)
+                                                                                   .build());
+    }
+
+    public Payment completePayment(final PaymentTransaction paymentTransaction, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         Preconditions.checkState(paymentTransaction.getPaymentId() != null || paymentTransaction.getPaymentExternalKey() != null, "PaymentTransaction#paymentId or PaymentTransaction#paymentExternalKey cannot be null");
 
         final String uri = (paymentTransaction.getPaymentId() != null) ?
                            JaxrsResource.PAYMENTS_PATH + "/" + paymentTransaction.getPaymentId() :
                            JaxrsResource.PAYMENTS_PATH;
 
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
         storePluginPropertiesAsParams(pluginProperties, params);
+        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(followLocation).build();
 
-        final Multimap<String, String> queryParams = paramsWithAudit(params,
-                                                                     createdBy,
-                                                                     reason,
-                                                                     comment);
-
-        return httpClient.doPutAndFollowLocation(uri, paymentTransaction, queryParams, Payment.class);
+        return httpClient.doPut(uri, paymentTransaction, Payment.class, requestOptions);
     }
 
+    @Deprecated
     public Payment captureAuthorization(final PaymentTransaction paymentTransaction, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return captureAuthorization(paymentTransaction, null, ImmutableMap.<String, String>of(), createdBy, reason, comment);
+        return captureAuthorization(paymentTransaction, RequestOptions.builder()
+                                                                      .withCreatedBy(createdBy)
+                                                                      .withReason(reason)
+                                                                      .withComment(comment)
+                                                                      .build());
     }
 
+    public Payment captureAuthorization(final PaymentTransaction paymentTransaction, final RequestOptions inputOptions) throws KillBillClientException {
+        return captureAuthorization(paymentTransaction, null, ImmutableMap.<String, String>of(), inputOptions);
+    }
+
+    @Deprecated
     public Payment captureAuthorization(final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return captureAuthorization(paymentTransaction, controlPluginNames, pluginProperties, RequestOptions.builder()
+                                                                                                            .withCreatedBy(createdBy)
+                                                                                                            .withReason(reason)
+                                                                                                            .withComment(comment)
+                                                                                                            .build());
+    }
+
+    public Payment captureAuthorization(final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         Preconditions.checkState(paymentTransaction.getPaymentId() != null || paymentTransaction.getPaymentExternalKey() != null, "PaymentTransaction#paymentId or PaymentTransaction#paymentExternalKey cannot be null");
         Preconditions.checkNotNull(paymentTransaction.getAmount(), "PaymentTransaction#amount cannot be null");
 
@@ -1059,27 +1134,43 @@ public class KillBillClient {
                            JaxrsResource.PAYMENTS_PATH + "/" + paymentTransaction.getPaymentId() :
                            JaxrsResource.PAYMENTS_PATH;
 
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
         storePluginPropertiesAsParams(pluginProperties, params);
-
         if (controlPluginNames != null) {
             params.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, controlPluginNames);
         }
 
+        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(followLocation).build();
 
-        final Multimap<String, String> queryParams = paramsWithAudit(params,
-                                                                     createdBy,
-                                                                     reason,
-                                                                     comment);
-
-        return httpClient.doPostAndFollowLocation(uri, paymentTransaction, queryParams, Payment.class);
+        return httpClient.doPost(uri, paymentTransaction, Payment.class, requestOptions);
     }
 
+    @Deprecated
     public Payment refundPayment(final PaymentTransaction paymentTransaction, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return refundPayment(paymentTransaction, null, ImmutableMap.<String, String>of(), createdBy, reason, comment);
+        return refundPayment(paymentTransaction, RequestOptions.builder()
+                                                               .withCreatedBy(createdBy)
+                                                               .withReason(reason)
+                                                               .withComment(comment)
+                                                               .build());
     }
 
+    public Payment refundPayment(final PaymentTransaction paymentTransaction, final RequestOptions inputOptions) throws KillBillClientException {
+        return refundPayment(paymentTransaction, null, ImmutableMap.<String, String>of(), inputOptions);
+    }
+
+    @Deprecated
     public Payment refundPayment(final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return refundPayment(paymentTransaction, controlPluginNames, pluginProperties, RequestOptions.builder()
+                                                                                                     .withCreatedBy(createdBy)
+                                                                                                     .withReason(reason)
+                                                                                                     .withComment(comment)
+                                                                                                     .build());
+    }
+
+    public Payment refundPayment(final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         Preconditions.checkState(paymentTransaction.getPaymentId() != null || paymentTransaction.getPaymentExternalKey() != null, "PaymentTransaction#paymentId or PaymentTransaction#paymentExternalKey cannot be null");
         Preconditions.checkNotNull(paymentTransaction.getAmount(), "PaymentTransaction#amount cannot be null");
 
@@ -1087,53 +1178,88 @@ public class KillBillClient {
                            JaxrsResource.PAYMENTS_PATH + "/" + paymentTransaction.getPaymentId() + "/" + JaxrsResource.REFUNDS :
                            JaxrsResource.PAYMENTS_PATH + "/" + JaxrsResource.REFUNDS;
 
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
         storePluginPropertiesAsParams(pluginProperties, params);
-
         if (controlPluginNames != null) {
             params.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, controlPluginNames);
         }
 
-        final Multimap<String, String> queryParams = paramsWithAudit(params,
-                                                                     createdBy,
-                                                                     reason,
-                                                                     comment);
+        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(followLocation).build();
 
-        return httpClient.doPostAndFollowLocation(uri, paymentTransaction, queryParams, Payment.class);
+        return httpClient.doPost(uri, paymentTransaction, Payment.class, requestOptions);
     }
 
+
+    @Deprecated
     public Payment chargebackPayment(final PaymentTransaction paymentTransaction, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return chargebackPayment(paymentTransaction, null, ImmutableMap.<String, String>of(), createdBy, reason, comment);
+        return chargebackPayment(paymentTransaction, RequestOptions.builder()
+                                                                   .withCreatedBy(createdBy)
+                                                                   .withReason(reason)
+                                                                   .withComment(comment)
+                                                                   .build());
     }
 
+    public Payment chargebackPayment(final PaymentTransaction paymentTransaction, final RequestOptions requestOptions) throws KillBillClientException {
+        return chargebackPayment(paymentTransaction, null, ImmutableMap.<String, String>of(), requestOptions);
+    }
+
+    @Deprecated
     public Payment chargebackPayment(final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return chargebackPayment(paymentTransaction, controlPluginNames, pluginProperties, RequestOptions.builder()
+                                                                                                         .withCreatedBy(createdBy)
+                                                                                                         .withReason(reason)
+                                                                                                         .withComment(comment)
+                                                                                                         .build());
+    }
+
+    public Payment chargebackPayment(final PaymentTransaction paymentTransaction, @Nullable final List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         Preconditions.checkState(paymentTransaction.getPaymentId() != null || paymentTransaction.getPaymentExternalKey() != null, "PaymentTransaction#paymentId or PaymentTransaction#paymentExternalKey cannot be null");
         Preconditions.checkNotNull(paymentTransaction.getAmount(), "PaymentTransaction#amount cannot be null");
 
         final String uri = (paymentTransaction.getPaymentId() != null) ?
                            JaxrsResource.PAYMENTS_PATH + "/" + paymentTransaction.getPaymentId() + "/" + JaxrsResource.CHARGEBACKS:
                            JaxrsResource.PAYMENTS_PATH + "/" + JaxrsResource.CHARGEBACKS;
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
 
-        final Multimap<String, String> queryParams = paramsWithAudit(params,
-                                                                     createdBy,
-                                                                     reason,
-                                                                     comment);
-
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
+        storePluginPropertiesAsParams(pluginProperties, params);
         if (controlPluginNames != null) {
             params.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, controlPluginNames);
         }
+        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(followLocation).build();
 
-        return httpClient.doPostAndFollowLocation(uri, paymentTransaction, queryParams, Payment.class);
+        return httpClient.doPost(uri, paymentTransaction, Payment.class, requestOptions);
     }
 
 
-
+    @Deprecated
     public Payment voidPayment(final UUID paymentId, final String transactionExternalKey, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return voidPayment(paymentId, null, transactionExternalKey, null, ImmutableMap.<String, String>of(), createdBy, reason, comment);
+        return voidPayment(paymentId, transactionExternalKey, RequestOptions.builder()
+                                                                            .withCreatedBy(createdBy)
+                                                                            .withReason(reason)
+                                                                            .withComment(comment)
+                                                                            .build());
     }
 
+    public Payment voidPayment(final UUID paymentId, final String transactionExternalKey, final RequestOptions inputOptions) throws KillBillClientException {
+        return voidPayment(paymentId, null, transactionExternalKey, null, ImmutableMap.<String, String>of(), inputOptions);
+    }
+
+    @Deprecated
     public Payment voidPayment(final UUID paymentId, final String paymentExternalKey, final String transactionExternalKey, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return voidPayment(paymentId, paymentExternalKey, transactionExternalKey, controlPluginNames, pluginProperties, RequestOptions.builder()
+                                                                                                                                      .withCreatedBy(createdBy)
+                                                                                                                                      .withReason(reason)
+                                                                                                                                      .withComment(comment)
+                                                                                                                                      .build());
+    }
+
+    public Payment voidPayment(final UUID paymentId, final String paymentExternalKey, final String transactionExternalKey, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
 
         Preconditions.checkState(paymentId != null || paymentExternalKey != null, "PaymentTransaction#paymentId or PaymentTransaction#paymentExternalKey cannot be null");
         final String uri = (paymentId != null) ?
@@ -1146,57 +1272,88 @@ public class KillBillClient {
         }
         paymentTransaction.setTransactionExternalKey(transactionExternalKey);
 
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
         storePluginPropertiesAsParams(pluginProperties, params);
-
         if (controlPluginNames != null) {
             params.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, controlPluginNames);
         }
 
-        final Multimap<String, String> queryParams = paramsWithAudit(params,
-                                                                     createdBy,
-                                                                     reason,
-                                                                     comment);
-
-        return httpClient.doDeleteAndFollowLocation(uri, paymentTransaction, queryParams, Payment.class);
+        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(followLocation).build();
+        return httpClient.doDelete(uri, paymentTransaction, Payment.class, requestOptions);
     }
 
     // Hosted payment pages
+    @Deprecated
     public HostedPaymentPageFormDescriptor buildFormDescriptor(final HostedPaymentPageFields fields, final UUID kbAccountId, @Nullable final UUID kbPaymentMethodId, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return buildFormDescriptor(fields, kbAccountId, kbPaymentMethodId, pluginProperties, RequestOptions.builder()
+                                                                                                           .withCreatedBy(createdBy)
+                                                                                                           .withReason(reason)
+                                                                                                           .withComment(comment)
+                                                                                                           .build());
+    }
+
+    public HostedPaymentPageFormDescriptor buildFormDescriptor(final HostedPaymentPageFields fields, final UUID kbAccountId, @Nullable final UUID kbPaymentMethodId, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
+        return buildFormDescriptor(fields, kbAccountId, kbPaymentMethodId, null, pluginProperties, inputOptions);
+    }
+
+    public HostedPaymentPageFormDescriptor buildFormDescriptor(final HostedPaymentPageFields fields, final UUID kbAccountId, @Nullable final UUID kbPaymentMethodId, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         final String uri = JaxrsResource.PAYMENT_GATEWAYS_PATH + "/" + JaxrsResource.HOSTED + "/" + JaxrsResource.FORM + "/" + kbAccountId;
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
+
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
         storePluginPropertiesAsParams(pluginProperties, params);
+        if (controlPluginNames != null) {
+            params.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, controlPluginNames);
+        }
         if (kbPaymentMethodId != null) {
             params.put(JaxrsResource.QUERY_PAYMENT_METHOD_ID, kbPaymentMethodId.toString());
         }
 
-        final Multimap<String, String> queryParams = paramsWithAudit(params,
-                                                                     createdBy,
-                                                                     reason,
-                                                                     comment);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(false).build();
 
-        return httpClient.doPost(uri, fields, queryParams, HostedPaymentPageFormDescriptor.class);
+        return httpClient.doPost(uri, fields, HostedPaymentPageFormDescriptor.class, requestOptions);
     }
 
+    @Deprecated
     public HostedPaymentPageFormDescriptor buildFormDescriptor(final ComboHostedPaymentPage comboHostedPaymentPage, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        return buildFormDescriptor(comboHostedPaymentPage, null, pluginProperties, createdBy, reason, comment);
+        return buildFormDescriptor(comboHostedPaymentPage, pluginProperties, RequestOptions.builder()
+                                                                                           .withCreatedBy(createdBy)
+                                                                                           .withReason(reason)
+                                                                                           .withComment(comment)
+                                                                                           .build());
     }
 
-    public HostedPaymentPageFormDescriptor buildFormDescriptor(final ComboHostedPaymentPage comboHostedPaymentPage, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
-        final String uri = JaxrsResource.PAYMENT_GATEWAYS_PATH + "/" + JaxrsResource.HOSTED + "/" + JaxrsResource.FORM;
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
+    public HostedPaymentPageFormDescriptor buildFormDescriptor(final ComboHostedPaymentPage comboHostedPaymentPage, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
+        return buildFormDescriptor(comboHostedPaymentPage, null, pluginProperties, inputOptions);
+    }
 
+    @Deprecated
+    public HostedPaymentPageFormDescriptor buildFormDescriptor(final ComboHostedPaymentPage comboHostedPaymentPage, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
+        return buildFormDescriptor(comboHostedPaymentPage, null, pluginProperties, RequestOptions.builder()
+                                                                                                 .withCreatedBy(createdBy)
+                                                                                                 .withReason(reason)
+                                                                                                 .withComment(comment)
+                                                                                                 .build());
+    }
+
+    public HostedPaymentPageFormDescriptor buildFormDescriptor(final ComboHostedPaymentPage comboHostedPaymentPage, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
+        final String uri = JaxrsResource.PAYMENT_GATEWAYS_PATH + "/" + JaxrsResource.HOSTED + "/" + JaxrsResource.FORM;
+
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
         if (controlPluginNames != null) {
             params.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, controlPluginNames);
         }
         storePluginPropertiesAsParams(pluginProperties, params);
 
-        final Multimap<String, String> queryParams = paramsWithAudit(params,
-                                                                     createdBy,
-                                                                     reason,
-                                                                     comment);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(false).build();
 
-        return httpClient.doPost(uri, comboHostedPaymentPage, queryParams, HostedPaymentPageFormDescriptor.class);
+        return httpClient.doPost(uri, comboHostedPaymentPage, HostedPaymentPageFormDescriptor.class, requestOptions);
     }
 
     public Response processNotification(final String notification, final String pluginName, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
@@ -1850,6 +2007,7 @@ public class KillBillClient {
         return uploadFile(pluginConfigInputStream, uri, "text/plain", createdBy, reason, comment, TenantKey.class);
     }
 
+    @Deprecated
     public TenantKey postPluginConfigurationPropertiesForTenant(final String pluginName, final String pluginConfigProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
         final RequestOptions options = RequestOptions.builder()
                                                .withCreatedBy(createdBy)

--- a/src/main/java/org/killbill/billing/client/KillBillClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillClient.java
@@ -949,20 +949,20 @@ public class KillBillClient {
         return httpClient.doGet(uri, queryParams, Payments.class);
     }
 
-    public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions options) throws KillBillClientException {
+    public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         final String uri = JaxrsResource.PAYMENTS_PATH + "/" + JaxrsResource.COMBO;
 
-        final Multimap<String, String> queryParams = HashMultimap.create(options.getQueryParams());
+        final Multimap<String, String> queryParams = HashMultimap.create(inputOptions.getQueryParams());
         if (controlPluginNames != null) {
             queryParams.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, controlPluginNames);
         }
         storePluginPropertiesAsParams(pluginProperties, queryParams);
 
-        final Boolean followLocation = MoreObjects.firstNonNull(options.getFollowLocation(), Boolean.TRUE);
-        final RequestOptions extendedOptions = options.extend()
-                                                      .withQueryParams(queryParams)
-                                                      .withFollowLocation(followLocation).build();
-        return httpClient.doPost(uri, comboPaymentTransaction, Payment.class, extendedOptions);
+        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(queryParams)
+                                                          .withFollowLocation(followLocation).build();
+        return httpClient.doPost(uri, comboPaymentTransaction, Payment.class, requestOptions);
     }
 
     public Payment createPayment(final ComboPaymentTransaction comboPaymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final String createdBy, final String reason, final String comment) throws KillBillClientException {
@@ -996,7 +996,7 @@ public class KillBillClient {
                              RequestOptions.builder().withCreatedBy(createdBy).withReason(reason).withComment(comment).build());
     }
 
-    public Payment createPayment(final UUID accountId, @Nullable final UUID paymentMethodId, final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions options) throws KillBillClientException {
+    public Payment createPayment(final UUID accountId, @Nullable final UUID paymentMethodId, final PaymentTransaction paymentTransaction, @Nullable List<String> controlPluginNames, final Map<String, String> pluginProperties, final RequestOptions inputOptions) throws KillBillClientException {
         Preconditions.checkNotNull(accountId, "accountId cannot be null");
         Preconditions.checkNotNull(paymentTransaction.getTransactionType(), "PaymentTransaction#transactionType cannot be null");
         Preconditions.checkArgument("AUTHORIZE".equals(paymentTransaction.getTransactionType()) ||
@@ -1009,7 +1009,7 @@ public class KillBillClient {
 
         final String uri = JaxrsResource.ACCOUNTS_PATH + "/" + accountId + "/" + JaxrsResource.PAYMENTS;
 
-        final Multimap<String, String> params = HashMultimap.<String, String>create();
+        final Multimap<String, String> params = HashMultimap.create(inputOptions.getQueryParams());
         if (paymentMethodId != null) {
             params.put("paymentMethodId", paymentMethodId.toString());
         }
@@ -1018,7 +1018,10 @@ public class KillBillClient {
         }
         storePluginPropertiesAsParams(pluginProperties, params);
 
-        final RequestOptions requestOptions = options.extend().withQueryParams(params).withFollowLocation(true).build();
+        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final RequestOptions requestOptions = inputOptions.extend()
+                                                          .withQueryParams(params)
+                                                          .withFollowLocation(followLocation).build();
         return httpClient.doPost(uri, paymentTransaction, Payment.class, requestOptions);
     }
 

--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -172,14 +172,17 @@ public class KillBillHttpClient implements Closeable {
 
     // POST
 
+    @Deprecated
     public Response doPost(final String uri, final Object body, final Multimap<String, String> options) throws KillBillClientException {
         return doPost(uri, body, options, Response.class);
     }
 
+    @Deprecated
     public <T> T doPost(final String uri, final Object body, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doPost(uri, body, options, requestTimeoutSec, clazz);
     }
 
+    @Deprecated
     public <T> T doPost(final String uri, final Object body, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         return doPostAndMaybeFollowLocation(uri, body, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz, false);
     }
@@ -197,22 +200,27 @@ public class KillBillHttpClient implements Closeable {
         return doPrepareRequest(verb, uri, body, returnClass, requestOptions, timeoutSec);
     }
 
+    @Deprecated
     public <T> T doPostAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doPostAndFollowLocation(uri, body, options, DEFAULT_EMPTY_QUERY, clazz);
     }
 
+    @Deprecated
     public <T> T doPostAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final Multimap<String, String> optionsForFollow, final Class<T> clazz) throws KillBillClientException {
         return doPostAndFollowLocation(uri, body, options, optionsForFollow, requestTimeoutSec, clazz);
     }
 
+    @Deprecated
     public <T> T doPostAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         return doPostAndFollowLocation(uri, body, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz);
     }
 
+    @Deprecated
     public <T> T doPostAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final Multimap<String, String> optionsForFollow, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         return doPostAndMaybeFollowLocation(uri, body, options, optionsForFollow, timeoutSec, clazz, true);
     }
 
+    @Deprecated
     public <T> T doPostAndMaybeFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final Multimap<String, String> optionsForFollow, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
         final String verb = "POST";
         return doPrepareRequestAndMaybeFollowLocation(verb, uri, body, options, optionsForFollow, timeoutSec, clazz, followLocation);
@@ -220,26 +228,32 @@ public class KillBillHttpClient implements Closeable {
 
     // PUT
 
+    @Deprecated
     public Response doPut(final String uri, final Object body, final Multimap<String, String> options) throws KillBillClientException {
         return doPut(uri, body, options, Response.class);
     }
 
+    @Deprecated
     public <T> T doPut(final String uri, final Object body, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doPut(uri, body, options, requestTimeoutSec, clazz);
     }
 
+    @Deprecated
     public <T> T doPut(final String uri, final Object body, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         return doPutAndMaybeFollowLocation(uri, body, options, timeoutSec, clazz, false);
     }
 
+    @Deprecated
     public <T> T doPutAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doPutAndFollowLocation(uri, body, options, requestTimeoutSec, clazz);
     }
 
+    @Deprecated
     public <T> T doPutAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         return doPutAndMaybeFollowLocation(uri, body, options, timeoutSec, clazz, true);
     }
 
+    @Deprecated
     public <T> T doPutAndMaybeFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
         final String verb = "PUT";
         return doPrepareRequestAndMaybeFollowLocation(verb, uri, body, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz, followLocation);
@@ -260,59 +274,48 @@ public class KillBillHttpClient implements Closeable {
 
     // DELETE
 
+    @Deprecated
     public Response doDelete(final String uri, final Multimap<String, String> options) throws KillBillClientException {
         return doDelete(uri, options, Response.class);
     }
 
+    @Deprecated
     public <T> T doDelete(final String uri, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doDeleteAndMaybeFollowLocation(uri, options, requestTimeoutSec, clazz, false);
     }
 
-    public <T> T doDeleteAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
-        return doDeleteAndFollowLocation(uri, body, options, requestTimeoutSec, clazz);
-    }
-
-    public <T> T doDeleteAndFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
-        return doDeleteAndMaybeFollowLocation(uri, body, options, timeoutSec, clazz, true);
-    }
-
+    @Deprecated
     public <T> T doDeleteAndMaybeFollowLocation(final String uri, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
         final String verb = "DELETE";
         return doPrepareRequestAndMaybeFollowLocation(verb, uri, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz, followLocation);
-    }
-
-    public <T> T doDeleteAndMaybeFollowLocation(final String uri, final Object body, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
-        final String verb = "DELETE";
-        return doPrepareRequestAndMaybeFollowLocation(verb, uri, body, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz, followLocation);
     }
 
     public Response doDelete(final String uri, final RequestOptions requestOptions) throws KillBillClientException {
         return doDelete(uri, null, Response.class, requestOptions);
     }
 
-    public <T> T doDelete(final String uri, Object body, Class<T> returnClass, final RequestOptions requestOptions) throws KillBillClientException {
+    public <T> T doDelete(final String uri, final Object body, final Class<T> returnClass, final RequestOptions requestOptions) throws KillBillClientException {
         return doDelete(uri, body, returnClass, requestOptions, this.requestTimeoutSec);
     }
 
-    public <T> T doDelete(final String uri, Object body, Class<T> returnClass, final RequestOptions requestOptions, int timeoutSec) throws KillBillClientException {
+    public <T> T doDelete(final String uri, final Object body, final Class<T> returnClass, final RequestOptions requestOptions, final int timeoutSec) throws KillBillClientException {
         final String verb = "DELETE";
         return doPrepareRequest(verb, uri, body, returnClass, requestOptions, timeoutSec);
     }
 
     // GET
 
+    @Deprecated
     public Response doGet(final String uri, final Multimap<String, String> options) throws KillBillClientException {
         return doGet(uri, options, Response.class);
     }
 
+    @Deprecated
     public <T> T doGet(final String uri, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doGetWithUrl(uri, options, requestTimeoutSec, clazz);
     }
 
-    public <T> T doGet(final String uri, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
-        return doGetWithUrl(uri, options, timeoutSec, clazz);
-    }
-
+    @Deprecated
     public <T> T doGetWithUrl(final String url, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         final String verb = "GET";
         return doPrepareRequestAndMaybeFollowLocation(verb, url, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz);
@@ -333,18 +336,17 @@ public class KillBillHttpClient implements Closeable {
 
     // HEAD
 
+    @Deprecated
     public Response doHead(final String uri, final Multimap<String, String> options) throws KillBillClientException {
         return doHead(uri, options, Response.class);
     }
 
+    @Deprecated
     public <T> T doHead(final String uri, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doHeadWithUrl(uri, options, requestTimeoutSec, clazz);
     }
 
-    public <T> T doHead(final String uri, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
-        return doHeadWithUrl(uri, options, timeoutSec, clazz);
-    }
-
+    @Deprecated
     public <T> T doHeadWithUrl(final String url, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         final String verb = "HEAD";
         return doPrepareRequestAndMaybeFollowLocation(verb, url, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz);
@@ -361,43 +363,43 @@ public class KillBillHttpClient implements Closeable {
 
     // OPTIONS
 
+    @Deprecated
     public Response doOptions(final String uri, final Multimap<String, String> options) throws KillBillClientException {
         return doOptions(uri, options, Response.class);
     }
 
+    @Deprecated
     public <T> T doOptions(final String uri, final Multimap<String, String> options, final Class<T> clazz) throws KillBillClientException {
         return doOptionsWithUrl(uri, options, requestTimeoutSec, clazz);
     }
 
-    public <T> T doOptions(final String uri, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
-        return doOptionsWithUrl(uri, options, timeoutSec, clazz);
-    }
-
+    @Deprecated
     public <T> T doOptionsWithUrl(final String url, final Multimap<String, String> options, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         final String verb = "OPTIONS";
         return doPrepareRequestAndMaybeFollowLocation(verb, url, options, DEFAULT_EMPTY_QUERY, timeoutSec, clazz);
     }
 
-    public Response doOptions(final String uri, RequestOptions requestOptions) throws KillBillClientException {
+    public Response doOptions(final String uri, final RequestOptions requestOptions) throws KillBillClientException {
         return doOptions(uri, requestOptions, this.requestTimeoutSec);
     }
 
-    public Response doOptions(final String uri, RequestOptions requestOptions, int timeoutSec) throws KillBillClientException {
+    public Response doOptions(final String uri, final RequestOptions requestOptions, final int timeoutSec) throws KillBillClientException {
         final String verb = "OPTIONS";
         return doPrepareRequest(verb, uri, null, Response.class, requestOptions, timeoutSec);
     }
 
     // COMMON
-
+    @Deprecated
     private <T> T doPrepareRequestAndMaybeFollowLocation(final String verb, final String uri, final Multimap<String, String> options, final Multimap<String, String> optionsForFollow, final int timeoutSec, final Class<T> clazz) throws KillBillClientException {
         return doPrepareRequestAndMaybeFollowLocation(verb, uri, null, options, optionsForFollow, timeoutSec, clazz, false);
     }
 
+    @Deprecated
     private <T> T doPrepareRequestAndMaybeFollowLocation(final String verb, final String uri, final Multimap<String, String> options, final Multimap<String, String> optionsForFollow, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
         return doPrepareRequestAndMaybeFollowLocation(verb, uri, null, options, optionsForFollow, timeoutSec, clazz, followLocation);
     }
 
-    private <T> T doPrepareRequest(final String verb, final String uri, final Object body, final Class<T> returnClass, RequestOptions requestOptions, int timeoutSec) throws KillBillClientException {
+    private <T> T doPrepareRequest(final String verb, final String uri, final Object body, final Class<T> returnClass, final RequestOptions requestOptions, final int timeoutSec) throws KillBillClientException {
         final BoundRequestBuilder builder = getBuilderWithHeaderAndQuery(verb, getKBServerUrl(uri), requestOptions);
 
         // Multi-Tenancy headers
@@ -461,6 +463,7 @@ public class KillBillHttpClient implements Closeable {
         }
     }
 
+    @Deprecated
     private <T> T doPrepareRequestAndMaybeFollowLocation(final String verb, final String uri, final Object body, final Multimap<String, String> optionsRo, final Multimap<String, String> optionsForFollow, final int timeoutSec, final Class<T> clazz, final boolean followLocation) throws KillBillClientException {
         final Multimap<String, String> options = HashMultimap.<String, String>create(optionsRo);
 
@@ -670,6 +673,7 @@ public class KillBillHttpClient implements Closeable {
         return result;
     }
 
+    @Deprecated
     private BoundRequestBuilder getBuilderWithHeaderAndQuery(final String verb, final String url, @Nullable final String username, @Nullable final String password, final Multimap<String, String> options) {
         BoundRequestBuilder builder;
 

--- a/src/main/java/org/killbill/billing/client/RequestOptions.java
+++ b/src/main/java/org/killbill/billing/client/RequestOptions.java
@@ -127,7 +127,7 @@ public class RequestOptions {
         return builder
                 .withRequestId(requestId)
                 .withUser(user).withPassword(password)
-                .withCreatedBy(createdBy).withCreatedBy(reason).withComment(comment)
+                .withCreatedBy(createdBy).withReason(reason).withComment(comment)
                 .withTenantApiKey(tenantApiKey).withTenantApiSecret(tenantApiSecret)
                 .withQueryParams(queryParams)
                 .withFollowLocation(followLocation).withQueryParamsForFollow(queryParamsForFollow);

--- a/src/main/java/org/killbill/billing/client/RequestOptions.java
+++ b/src/main/java/org/killbill/billing/client/RequestOptions.java
@@ -141,6 +141,14 @@ public class RequestOptions {
         return new RequestOptionsBuilder();
     }
 
+    /**
+     * Helper method for creating an empty RequestOptions object.
+     * @return an empty RequestOptions object.
+     */
+    public static RequestOptions empty() {
+        return new RequestOptionsBuilder().build();
+    }
+
     public static class RequestOptionsBuilder {
 
         private String requestId;

--- a/src/main/java/org/killbill/billing/client/RequestOptions.java
+++ b/src/main/java/org/killbill/billing/client/RequestOptions.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2016 Groupon, Inc
+ * Copyright 2016 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Created by arodrigues on 5/24/16.
+ */
+public class RequestOptions {
+
+    private final String requestId;
+
+    private final String user, password;
+
+    private final String createdBy, reason, comment;
+
+    private final String tenantApiKey, tenantApiSecret;
+
+    private final ImmutableMap<String, String> headers;
+
+    private final ImmutableMultimap<String, String> queryParams;
+
+    private final Boolean followLocation;
+
+    private final Multimap<String, String> queryParamsForFollow;
+
+    public RequestOptions(final String requestId, final String user, final String password, final String createdBy,
+                          final String reason, final String comment, final String tenantApiKey, final String tenantApiSecret,
+                          final Map<String, String> headers, final Multimap<String, String> queryParams,
+                          final Boolean followLocation, final Multimap<String, String> queryParamsForFollow) {
+        this.requestId = requestId;
+        this.user = user;
+        this.password = password;
+        this.createdBy = createdBy;
+        this.reason = reason;
+        this.comment = comment;
+        this.tenantApiKey = tenantApiKey;
+        this.tenantApiSecret = tenantApiSecret;
+        this.headers = (headers != null) ? ImmutableMap.copyOf(headers) : ImmutableMap.<String, String>of();
+        this.queryParams = (queryParams != null) ? ImmutableMultimap.copyOf(queryParams) : ImmutableMultimap.<String, String>of();
+        this.followLocation = followLocation;
+        this.queryParamsForFollow = ImmutableMultimap.copyOf(queryParamsForFollow);
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public String getTenantApiKey() {
+        return tenantApiKey;
+    }
+
+    public String getTenantApiSecret() {
+        return tenantApiSecret;
+    }
+
+    public ImmutableMap<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    public ImmutableMultimap<String, String> getQueryParams() {
+        return queryParams;
+    }
+
+    public Boolean getFollowLocation() {
+        return followLocation;
+    }
+
+    public boolean shouldFollowLocation() {
+        if (followLocation == null) {
+            return false;
+        }
+        return followLocation;
+    }
+
+    public Multimap<String, String> getQueryParamsForFollow() {
+        return queryParamsForFollow;
+    }
+
+    public RequestOptionsBuilder extend() {
+        final RequestOptionsBuilder builder = new RequestOptionsBuilder();
+        builder.headers.putAll(this.headers);
+        return builder
+                .withRequestId(requestId)
+                .withUser(user).withPassword(password)
+                .withCreatedBy(createdBy).withCreatedBy(reason).withComment(comment)
+                .withTenantApiKey(tenantApiKey).withTenantApiSecret(tenantApiSecret)
+                .withQueryParams(queryParams)
+                .withFollowLocation(followLocation).withQueryParamsForFollow(queryParamsForFollow);
+    }
+
+    /**
+     * Helper method for creating a new builder
+     * @return a new instance of RequestOptionsBuilder
+     */
+    public static RequestOptionsBuilder builder() {
+        return new RequestOptionsBuilder();
+    }
+
+    public static class RequestOptionsBuilder {
+
+        private String requestId;
+
+        private String user, password;
+
+        private String createdBy, reason, comment;
+
+        private String tenantApiKey, tenantApiSecret;
+
+        private final Map<String, String> headers = new HashMap<String, String>();
+
+        private Multimap<String, String> queryParams = HashMultimap.<String, String>create();
+
+        private Boolean followLocation;
+
+        private Multimap<String, String> queryParamsForFollow = HashMultimap.<String, String>create();
+
+        public RequestOptionsBuilder withRequestId(final String requestId) {
+            this.requestId = requestId;
+            return this;
+        }
+
+        public RequestOptionsBuilder withUser(final String user) {
+            this.user = user;
+            return this;
+        }
+
+        public RequestOptionsBuilder withPassword(final String password) {
+            this.password = password;
+            return this;
+        }
+
+        public RequestOptionsBuilder withCreatedBy(final String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        public RequestOptionsBuilder withReason(final String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        public RequestOptionsBuilder withComment(final String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public RequestOptionsBuilder withTenantApiKey(final String tenantApiKey) {
+            this.tenantApiKey = tenantApiKey;
+            return this;
+        }
+
+        public RequestOptionsBuilder withTenantApiSecret(final String tenantApiSecret) {
+            this.tenantApiSecret = tenantApiSecret;
+            return this;
+        }
+
+        public RequestOptionsBuilder withHeader(final String header, final String value) {
+            this.headers.put(header, value);
+            return this;
+        }
+
+        public RequestOptionsBuilder withQueryParams(final Multimap<String, String> queryParams) {
+            this.queryParams = queryParams;
+            return this;
+        }
+
+        public RequestOptionsBuilder withFollowLocation(final Boolean followLocation) {
+            this.followLocation = followLocation;
+            return this;
+        }
+
+        public RequestOptionsBuilder withQueryParamsForFollow(final Multimap<String, String> queryParamsForFollow) {
+            this.queryParamsForFollow = queryParamsForFollow;
+            return this;
+        }
+
+        public RequestOptions build() {
+            return new RequestOptions(requestId, user, password, createdBy, reason, comment, tenantApiKey, tenantApiSecret,
+                                      headers, queryParams, followLocation, queryParamsForFollow);
+        }
+    }
+}

--- a/src/test/java/org/killbill/billing/client/TestKillBillHttpClient.java
+++ b/src/test/java/org/killbill/billing/client/TestKillBillHttpClient.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2016 Groupon, Inc
+ * Copyright 2016 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client;
+
+import java.util.UUID;
+
+import org.killbill.billing.client.model.PaymentTransaction;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.ning.http.client.Response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.common.collect.ImmutableMultimap;
+
+import static org.testng.Assert.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+/**
+ * Created by arodrigues on 5/28/16.
+ */
+@Test(groups = "fast")
+public class TestKillBillHttpClient {
+
+    private WireMockServer server;
+
+    private KillBillHttpClient httpClient;
+    private final String apiKey = "bob";
+    private final String apiSecret = "lazar";
+
+    @BeforeClass
+    public void startServer() {
+        server = new WireMockServer();
+        server.start();
+    }
+
+    @AfterClass
+    public void stopServer() {
+        server.stop();
+    }
+    private String serverBaseUrl() {
+        return String.format("http://localhost:%d", server.port());
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        final String user = "admin";
+        final String password = "password";
+        httpClient = new KillBillHttpClient(serverBaseUrl(), user, password, apiKey, apiSecret);
+        WireMock.reset();
+    }
+
+    @Test
+    public void testDoPost() throws Exception {
+        final String path = JaxrsResource.PAYMENTS_PATH;
+        final String requestId = randomString();
+        final String createdBy = "demo";
+        final String reason = "test";
+        final String comment = "No comments";
+        stubFor(withAuthHeaders(
+                post(urlEqualTo(path))
+                        .withHeader(JaxrsResource.HDR_REQUEST_ID, equalTo(requestId))
+                        .withHeader(JaxrsResource.HDR_CREATED_BY, equalTo(createdBy))
+                        .withHeader(JaxrsResource.HDR_REASON, equalTo(reason))
+                        .withHeader(JaxrsResource.HDR_COMMENT, equalTo(comment))
+                        .willReturn(aResponse().withStatus(200)))
+               );
+
+
+        final RequestOptions options = RequestOptions.builder()
+                                                     .withRequestId(requestId)
+                                                     .withCreatedBy(createdBy)
+                                                     .withReason(reason)
+                                                     .withComment(comment)
+                                                     .build();
+        final PaymentTransaction transaction = new PaymentTransaction();
+        final Response response = httpClient.doPost(path, transaction, options);
+
+        verify(postRequestedFor(urlEqualTo(path)));
+
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testDoPostFollowingLocation() throws Exception {
+        final String path = JaxrsResource.PAYMENTS_PATH;
+        final String requestId = randomString();
+        final String createdBy = "demo";
+        final String reason = "test";
+        final String comment = "No comments";
+        final String locationToFollow = "/location-to-follow";
+        stubFor(withAuthHeaders(
+                post(urlEqualTo(path))
+                        .withHeader(JaxrsResource.HDR_REQUEST_ID, equalTo(requestId))
+                        .withHeader(JaxrsResource.HDR_CREATED_BY, equalTo(createdBy))
+                        .withHeader(JaxrsResource.HDR_REASON, equalTo(reason))
+                        .withHeader(JaxrsResource.HDR_COMMENT, equalTo(comment))
+                        .willReturn(aResponse()
+                                            .withHeader("Location", serverBaseUrl() + locationToFollow)
+                                            .withStatus(201)))
+               );
+        final String responseBody = "Success";
+        stubFor(get(urlEqualTo(locationToFollow))
+                .withHeader("X-Request-Id", equalTo(requestId))
+                .willReturn(aResponse()
+                            .withStatus(200)
+                            .withBody(responseBody)));
+
+        final RequestOptions options = RequestOptions.builder()
+                                                     .withRequestId(requestId)
+                                                     .withCreatedBy(createdBy)
+                                                     .withReason(reason)
+                                                     .withComment(comment)
+                                                     .withFollowLocation(true)
+                                                     .build();
+        final PaymentTransaction transaction = new PaymentTransaction();
+        final Response response = httpClient.doPost(path, transaction, options);
+
+        verify(postRequestedFor(urlEqualTo(path)));
+        verify(getRequestedFor(
+                urlMatching(locationToFollow))
+                       .withHeader(JaxrsResource.HDR_REQUEST_ID, equalTo(requestId))
+                       .withoutHeader(JaxrsResource.HDR_CREATED_BY)
+                       .withoutHeader(JaxrsResource.HDR_REASON)
+                       .withoutHeader(JaxrsResource.HDR_COMMENT));
+
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+        assertEquals(response.getResponseBody(), responseBody);
+    }
+
+    @Test
+    public void testPostWithQueryParams() throws Exception {
+        final String path = JaxrsResource.PAYMENTS_PATH;
+        final String paramName = "param";
+        final String queryParam = randomString();
+        final String locationToFollow = "/location-to-follow";
+        stubFor(post(urlPathEqualTo(path))
+                .withQueryParam(paramName, equalTo(queryParam))
+                .willReturn(aResponse()
+                            .withStatus(201)
+                            .withHeader("Location", serverBaseUrl() + locationToFollow)));
+
+        final String followParamName = "follow-param";
+        final String followParam = randomString();
+        stubFor(get(urlPathEqualTo(locationToFollow))
+                .withQueryParam(followParamName, equalTo(followParam))
+                .willReturn(aResponse()
+                            .withStatus(200)));
+
+        final RequestOptions options = RequestOptions.builder()
+                                                     .withQueryParams(ImmutableMultimap.of(paramName, queryParam))
+                                                     .withFollowLocation(true)
+                                                     .withQueryParamsForFollow(ImmutableMultimap.of(followParamName, followParam))
+                                                     .build();
+        final String body = "Some body!";
+        final Response response = httpClient.doPost(path, body, options);
+
+        verify(postRequestedFor(urlPathEqualTo(path)).withQueryParam(paramName, equalTo(queryParam)).withRequestBody(equalTo(body)));
+        verify(getRequestedFor(urlPathEqualTo(locationToFollow)).withQueryParam(followParamName, equalTo(followParam)));
+
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testDoGetWithCustomHeader() throws Exception {
+        final String path = "/some-path";
+        final String acceptHeader = randomString();
+        stubFor(get(urlPathEqualTo(path))
+                    .withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, equalTo(acceptHeader))
+                    .willReturn(aResponse().withStatus(200)));
+
+        final RequestOptions options = RequestOptions.builder()
+                                                     .withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, acceptHeader).build();
+        final Response response = httpClient.doGet(path, options);
+
+        verify(getRequestedFor(urlPathEqualTo(path)).withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, equalTo(acceptHeader)));
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testDoPut() throws Exception {
+        final String path = "/put/some-path";
+        final String body = randomString();
+        final String contentType = randomString();
+        stubFor(put(urlPathEqualTo(path))
+                .withRequestBody(equalTo(body))
+                .withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, equalTo(contentType))
+                .willReturn(aResponse().withStatus(200)));
+
+        final RequestOptions options = RequestOptions.builder()
+                                                     .withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, contentType)
+                                                     .build();
+        final Response response = httpClient.doPut(path, body, options);
+
+        verify(putRequestedFor(urlPathEqualTo(path))
+               .withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, equalTo(contentType))
+               .withRequestBody(equalTo(body)));
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testDoDelete() throws Exception {
+        final String path = String.format("/%s", randomString());
+        stubFor(delete(urlPathEqualTo(path)).willReturn(aResponse().withStatus(200)));
+
+        final Response response = httpClient.doDelete(path, RequestOptions.empty());
+
+        verify(deleteRequestedFor(urlPathEqualTo(path)));
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testDoDeleteWithBody() throws Exception {
+        final String path = String.format("/%s", randomString());
+        final PaymentTransaction transaction = new PaymentTransaction();
+        transaction.setTransactionId(UUID.randomUUID());
+        transaction.setTransactionType("CAPTURE");
+        final String body = new ObjectMapper().writeValueAsString(transaction);
+        stubFor(delete(urlPathEqualTo(path)).withRequestBody(equalTo(body)).willReturn(aResponse().withStatus(200)));
+
+        final Response response = httpClient.doDelete(path, body, Response.class, RequestOptions.empty());
+
+        verify(deleteRequestedFor(urlPathEqualTo(path)).withRequestBody(equalTo(body)));
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testDoHead() throws Exception {
+        final String path = String.format("/%s", randomString());
+        stubFor(head(urlPathEqualTo(path)).willReturn(aResponse().withStatus(200)));
+
+        final Response response = httpClient.doHead(path, RequestOptions.empty());
+
+        verify(headRequestedFor(urlPathEqualTo(path)));
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void testDoOptions() throws Exception {
+        final String path = String.format("/%s", randomString());
+        stubFor(options(urlPathEqualTo(path)).willReturn(aResponse().withStatus(200)));
+
+        final Response response = httpClient.doOptions(path, RequestOptions.empty());
+
+        verify(optionsRequestedFor(urlPathEqualTo(path)));
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    private String randomString() {
+        return UUID.randomUUID().toString();
+    }
+
+    private MappingBuilder withAuthHeaders(final MappingBuilder mappingBuilder) {
+        return withAuthHeaders(this.apiKey, this.apiSecret, mappingBuilder);
+    }
+
+    private MappingBuilder withAuthHeaders(final String apiKey, final String apiSecret, final MappingBuilder mappingBuilder) {
+        return mappingBuilder
+                .withHeader(JaxrsResource.HDR_API_KEY, equalTo(apiKey))
+                .withHeader(JaxrsResource.HDR_API_SECRET, equalTo(apiSecret));
+    }
+}

--- a/src/test/java/org/killbill/billing/client/TestRequestOptions.java
+++ b/src/test/java/org/killbill/billing/client/TestRequestOptions.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2016 Groupon, Inc
+ * Copyright 2016 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client;
+
+import java.util.UUID;
+
+import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Created by arodrigues on 5/27/16.
+ */
+@Test(groups = "fast")
+public class TestRequestOptions {
+
+    private final RequestOptionsBuilder builder = RequestOptions.builder();
+
+    @Test
+    public void testBuilder() {
+        final String requestId = randomString();
+        builder.withRequestId(requestId);
+        final String user = randomString();
+        builder.withUser(user);
+        final String password = randomString();
+        builder.withPassword(password);
+        final String createdBy = randomString();
+        builder.withCreatedBy(createdBy);
+        final String reason = randomString();
+        builder.withReason(reason);
+        final String comment = randomString();
+        builder.withComment(comment);
+        final String tenantApiKey = randomString();
+        builder.withTenantApiKey(tenantApiKey);
+        final String tenantApiSecret = randomString();
+        builder.withTenantApiSecret(tenantApiSecret);
+
+        final RequestOptions options = builder.build();
+        Assert.assertEquals(options.getRequestId(), requestId);
+        Assert.assertEquals(options.getUser(), user);
+        Assert.assertEquals(options.getPassword(), password);
+        Assert.assertEquals(options.getCreatedBy(), createdBy);
+        Assert.assertEquals(options.getReason(), reason);
+        Assert.assertEquals(options.getComment(), comment);
+        Assert.assertEquals(options.getTenantApiKey(), tenantApiKey);
+        Assert.assertEquals(options.getTenantApiSecret(), tenantApiSecret);
+    }
+
+    @Test
+    public void testBuilderWithQueryParams() {
+        final Multimap<String, String> queryParams = ArrayListMultimap.<String, String>create();
+        queryParams.put("test-param", randomString());
+        builder.withQueryParams(queryParams);
+
+        final Multimap<String, String> queryParamsForFollow = ArrayListMultimap.<String, String>create();
+        queryParamsForFollow.put("test-param-for-follow", randomString());
+        builder.withQueryParamsForFollow(queryParamsForFollow);
+
+        final RequestOptions options = builder.build();
+        Assert.assertNotSame(options.getQueryParams(), queryParams);
+        Assert.assertEquals(options.getQueryParams(), queryParams);
+
+        Assert.assertNotSame(options.getQueryParamsForFollow(), queryParamsForFollow);
+        Assert.assertEquals(options.getQueryParamsForFollow(), queryParamsForFollow);
+    }
+
+    @Test
+    public void testBuilderWithHeaders() {
+        final String header = randomString();
+        builder.withHeader("test-header", header);
+
+        final RequestOptions options = builder.build();
+        Assert.assertEquals(options.getHeaders().get("test-header"), header);
+    }
+
+    @Test
+    public void testBuilderWithNullFollowLocation() {
+        builder.withFollowLocation(null);
+
+        final RequestOptions options = builder.build();
+        Assert.assertNull(options.getFollowLocation());
+        Assert.assertFalse(options.shouldFollowLocation());
+    }
+
+    @Test
+    public void testBuilderWithFollowLocation() {
+        final Boolean follow = Boolean.TRUE;
+        builder.withFollowLocation(follow);
+
+        final RequestOptions options = builder.build();
+        Assert.assertEquals(options.getFollowLocation(), follow);
+        Assert.assertTrue(options.shouldFollowLocation());
+    }
+
+    @Test
+    public void testBuilderWithFollowLocationFalse() {
+        final Boolean follow = Boolean.FALSE;
+        builder.withFollowLocation(follow);
+
+        final RequestOptions options = builder.build();
+        Assert.assertEquals(options.getFollowLocation(), follow);
+        Assert.assertFalse(options.shouldFollowLocation());
+    }
+
+    @Test
+    public void testExtend() {
+        final String requestId = randomString();
+        builder.withRequestId(requestId);
+        final String user = randomString();
+        builder.withUser(user);
+        final String password = randomString();
+        builder.withPassword(password);
+        final String createdBy = randomString();
+        builder.withCreatedBy(createdBy);
+        final String reason = randomString();
+        builder.withReason(reason);
+        final String comment = randomString();
+        builder.withComment(comment);
+        final String tenantApiKey = randomString();
+        builder.withTenantApiKey(tenantApiKey);
+        final String tenantApiSecret = randomString();
+        builder.withTenantApiSecret(tenantApiSecret);
+        final Multimap<String, String> queryParams = ImmutableMultimap.of("param", randomString());
+        builder.withQueryParams(queryParams);
+        final String header = randomString();
+        builder.withHeader("test-header", header);
+        final Boolean followLocation = true;
+        builder.withFollowLocation(followLocation);
+        final Multimap<String, String> queryParamsForFollow = ImmutableMultimap.of("param-for-follow", randomString());
+        builder.withQueryParamsForFollow(queryParamsForFollow);
+
+        final RequestOptions extendedOptions = builder.build().extend().build();
+        Assert.assertEquals(extendedOptions.getRequestId(), requestId);
+        Assert.assertEquals(extendedOptions.getUser(), user);
+        Assert.assertEquals(extendedOptions.getPassword(), password);
+        Assert.assertEquals(extendedOptions.getCreatedBy(), createdBy);
+        Assert.assertEquals(extendedOptions.getReason(), reason);
+        Assert.assertEquals(extendedOptions.getComment(), comment);
+        Assert.assertEquals(extendedOptions.getTenantApiKey(), tenantApiKey);
+        Assert.assertEquals(extendedOptions.getTenantApiSecret(), tenantApiSecret);
+        Assert.assertEquals(extendedOptions.getHeaders().get("test-header"), header);
+        Assert.assertEquals(extendedOptions.getQueryParams(), queryParams);
+        Assert.assertEquals(extendedOptions.getFollowLocation(), followLocation);
+        Assert.assertEquals(extendedOptions.getQueryParamsForFollow(), queryParamsForFollow);
+    }
+
+    private String randomString() {
+        return UUID.randomUUID().toString();
+    }
+}


### PR DESCRIPTION
WIP: This is a first step in using the `RequestOptions` class in the `createPayment` method (combo payment).

I've also made a change to another method that passes a header to the http client, the `postPluginConfigurationPropertiesForTenant` method.

In the Http Client, there're overloads of both `doGet` and `doPost` methods using the new options class. In order to isolate the changes, I've created a copy of the `doPrepareRequestAndMaybeFollowLocation` method, called `doPrepareRequest`, that takes an instance of `RequestOptions` as a parameter. I did the same of the `getBuilderWithHeaderAndQuery` method.

I think this should be enough to iterate on the design and get a feel of how the new class would be used. I've run the tests in the profiles module of killbill using the new client and the tests passed.