### PR TITLE
FollowLocation Fixes

### DIFF
--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -497,8 +497,6 @@ public class KillBillHttpClient implements Closeable {
                                                                       .build();
                 return doGet(location, returnClass, optionsForFollow, timeoutSec);
             }
-            throwExceptionOnResponseError(response);
-            return Response.class.isAssignableFrom(returnClass) ? returnClass.cast(response) : null;
         }
         throwExceptionOnResponseError(response);
         return deserializeResponse(response, returnClass);
@@ -643,6 +641,11 @@ public class KillBillHttpClient implements Closeable {
         // No deserialization required
         if (Response.class.isAssignableFrom(clazz)) {
             return clazz.cast(response);
+        }
+
+        // Nothing to deserialize
+        if(!response.hasResponseBody()) {
+            return createEmptyResult(clazz);
         }
 
         final T result = unmarshalResponse(response, clazz);


### PR DESCRIPTION
Fix for `com.fasterxml.jackson.databind.JsonMappingException: No content to map due to end-of-input` when creating an object (ex `createAccount`) with `followLocation` set to `false`. Fix for issue where getting a list of objects (ex `getAccounts`) returns null when `followLocation` is set to `true`.

To reproduce issues:
```
RequestOptions requestOptions = RequestOptions.builder().withCreatedBy('test').withFollowLocation(false).build();
Account account = new Account();
killbill.createAccount(account, requestOptions);  //throws exception
```

```
RequestOptions requestOptions = RequestOptions.builder().withCreatedBy('test').withFollowLocation(true).build();
Accounts accounts = killbill.getAccounts(requestOptions);  //returns null
```

Let me know if you see any issues or I need to make any changes! :bowtie: 