### PR TITLE
remove trailing slash in server address default config

### DIFF
--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -200,7 +200,7 @@ public class KillBillHttpClient implements Closeable {
     }
 
     public KillBillHttpClient() {
-        this(System.getProperty("killbill.url", "http://127.0.0.1:8080/"),
+        this(System.getProperty("killbill.url", "http://127.0.0.1:8080"),
              System.getProperty("killbill.username", "admin"),
              System.getProperty("killbill.password", "password"),
              System.getProperty("killbill.apiKey", "bob"),


### PR DESCRIPTION
all URIs in `api/gen` starts with a slash