### PR TITLE
Add equals/hashCode to KillBillObject

### DIFF
--- a/src/main/java/org/killbill/billing/client/model/KillBillObject.java
+++ b/src/main/java/org/killbill/billing/client/model/KillBillObject.java
@@ -21,6 +21,7 @@ package org.killbill.billing.client.model;
 
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -44,5 +45,22 @@ public abstract class KillBillObject {
 
     public void setAuditLogs(final List<AuditLog> auditLogs) {
         this.auditLogs = auditLogs;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof KillBillObject)) {
+            return false;
+        }
+        final KillBillObject that = (KillBillObject) o;
+        return Objects.equals(auditLogs, that.auditLogs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(auditLogs);
     }
 }


### PR DESCRIPTION
Mitigates https://github.com/killbill/killbill-swagger-coden/issues/17

The generated code still uses the `protected` field for its `equals` instead of calling `super`.
But the `super.hashCode` call will now return a useful value.

With all the model code being generated this solves the immediate problem, but fixing the model templates/Swagger generator should still be considered, if possible.

