### PR TITLE
1615 - Add new methods to RequestOptions and fix various error

### DIFF
--- a/.swagger-codegen/KB_VERSION
+++ b/.swagger-codegen/KB_VERSION
@@ -1,4 +1,4 @@
 swaggerVersion=2.4.1
 kbVersion=0.23.0-SNAPSHOT
-kbApiVersion=0.54.0-05dc842-SNAPSHOT
-kbPluginApiVersion=0.27.0-a4410f3-SNAPSHOT
+kbApiVersion=0.54.0-SNAPSHOT
+kbPluginApiVersion=0.27.0-af603fc-SNAPSHOT

--- a/.swagger-codegen/kbswagger.yaml
+++ b/.swagger-codegen/kbswagger.yaml
@@ -176,6 +176,469 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/accounts:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve an account by external key"
+      description: ""
+      operationId: "getAccountByKey"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "externalKey"
+        in: "query"
+        required: true
+        type: "string"
+      - name: "accountWithBalance"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "accountWithBalanceAndCBA"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Account"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Account"
+      summary: "Create account"
+      description: ""
+      operationId: "createAccount"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Account"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Account created successfully"
+          schema:
+            $ref: "#/definitions/Account"
+        "400":
+          description: "Invalid account data supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/search/{searchKey}:
+    get:
+      tags:
+      - "Account"
+      summary: "Search accounts"
+      description: ""
+      operationId: "searchAccounts"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "searchKey"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int64"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 100
+        format: "int64"
+      - name: "accountWithBalance"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "accountWithBalanceAndCBA"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Account"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/emails:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve an account emails"
+      description: ""
+      operationId: "getEmails"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AccountEmail"
+        "400":
+          description: "Invalid account id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Account"
+      summary: "Add account email"
+      description: ""
+      operationId: "addEmail"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/AccountEmail"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Email created successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AccountEmail"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/emails/{email}:
+    delete:
+      tags:
+      - "Account"
+      summary: "Delete email from account"
+      description: ""
+      operationId: "removeEmail"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "email"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid account id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/pagination:
+    get:
+      tags:
+      - "Account"
+      summary: "List accounts"
+      description: ""
+      operationId: "getAccounts"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int64"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 100
+        format: "int64"
+      - name: "accountWithBalance"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "accountWithBalanceAndCBA"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Account"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve an account by id"
+      description: ""
+      operationId: "getAccount"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "accountWithBalance"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "accountWithBalanceAndCBA"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Account"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    put:
+      tags:
+      - "Account"
+      summary: "Update account"
+      description: ""
+      operationId: "updateAccount"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Account"
+      - name: "treatNullAsReset"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid account data supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    delete:
+      tags:
+      - "Account"
+      summary: "Close account"
+      description: ""
+      operationId: "closeAccount"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "cancelAllSubscriptions"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "writeOffUnpaidInvoices"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "itemAdjustUnpaidInvoices"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "removeFutureNotifications"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: true
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid account id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/accounts/{accountId}/children:
     get:
       tags:
@@ -222,6 +685,133 @@ paths:
           description: "Invalid parent account id supplied"
         "404":
           description: "Parent Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/invoicePayments:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve account invoice payments"
+      description: ""
+      operationId: "getInvoicePayments"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "withPluginInfo"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "withAttempts"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/InvoicePayment"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Account"
+      summary: "Trigger a payment for all unpaid invoices"
+      description: ""
+      operationId: "payAllInvoices"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "paymentMethodId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      - name: "externalPayment"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "paymentAmount"
+        in: "query"
+        required: false
+        type: "number"
+      - name: "targetDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Invoice"
+        "204":
+          description: "Nothing to pay"
+        "404":
+          description: "Invalid account id supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -335,6 +925,121 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/block:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve blocking states for account"
+      description: ""
+      operationId: "getBlockingStates"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "blockingStateTypes"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+          enum:
+          - "SUBSCRIPTION"
+          - "SUBSCRIPTION_BUNDLE"
+          - "ACCOUNT"
+        collectionFormat: "multi"
+      - name: "blockingStateSvcs"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/BlockingState"
+        "400":
+          description: "Invalid account id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Account"
+      summary: "Block an account"
+      description: ""
+      operationId: "addAccountBlockingState"
+      consumes:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/BlockingState"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Blocking state created successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/BlockingState"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/accounts/{childAccountId}/transferCredit:
     put:
       tags:
@@ -376,78 +1081,31 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/accounts/payments:
-    post:
+  /1.0/kb/accounts/{accountId}/auditLogs:
+    get:
       tags:
       - "Account"
-      summary: "Trigger a payment using the account external key (authorization, purchase\
-        \ or credit)"
+      summary: "Retrieve audit logs by account id"
       description: ""
-      operationId: "processPaymentByExternalKey"
-      consumes:
-      - "application/json"
+      operationId: "getAccountAuditLogs"
       produces:
       - "application/json"
       parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentTransaction"
-      - name: "externalKey"
-        in: "query"
+      - name: "accountId"
+        in: "path"
         required: true
         type: "string"
-      - name: "paymentMethodId"
-        in: "query"
-        required: false
-        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
         format: "uuid"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
       responses:
-        "201":
-          description: "Payment transaction created successfully"
+        "200":
+          description: "successful operation"
           schema:
-            $ref: "#/definitions/Payment"
-        "400":
-          description: "Invalid account external key supplied"
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
         "404":
           description: "Account not found"
-        "402":
-          description: "Transaction declined by gateway"
-        "422":
-          description: "Payment is aborted by a control plugin"
-        "502":
-          description: "Failed to submit payment transaction"
-        "503":
-          description: "Payment in unknown status, failed to receive gateway response"
-        "504":
-          description: "Payment operation timeout"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -630,114 +1288,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/invoices:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve account invoices"
-      description: ""
-      operationId: "getInvoicesForAccount"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "startDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "endDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "withMigrationInvoices"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "unpaidInvoicesOnly"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "includeVoidedInvoices"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "invoicesFilter"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Invoice"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/cbaRebalancing:
-    put:
-      tags:
-      - "Account"
-      summary: "Rebalance account CBA"
-      description: ""
-      operationId: "rebalanceExistingCBAOnAccount"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid account id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/accounts/{accountId}/paymentMethods:
     get:
       tags:
@@ -895,6 +1445,392 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/bundles:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve bundles for account"
+      description: ""
+      operationId: "getAccountBundles"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "externalKey"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "bundlesFilter"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Bundle"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/emails/{accountEmailId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve account email audit logs with history by id"
+      description: ""
+      operationId: "getAccountEmailAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "accountEmailId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/timeline:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve account timeline"
+      description: ""
+      operationId: "getAccountTimeline"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "parallel"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AccountTimeline"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/allCustomFields:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve account customFields"
+      description: ""
+      operationId: "getAllCustomFields"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "objectType"
+        in: "query"
+        required: false
+        type: "string"
+        enum:
+        - "ACCOUNT"
+        - "ACCOUNT_EMAIL"
+        - "BLOCKING_STATES"
+        - "BUNDLE"
+        - "CUSTOM_FIELD"
+        - "INVOICE"
+        - "PAYMENT"
+        - "TRANSACTION"
+        - "INVOICE_ITEM"
+        - "INVOICE_PAYMENT"
+        - "SUBSCRIPTION"
+        - "SUBSCRIPTION_EVENT"
+        - "SERVICE_BROADCAST"
+        - "PAYMENT_ATTEMPT"
+        - "PAYMENT_METHOD"
+        - "TAG"
+        - "TAG_DEFINITION"
+        - "TENANT"
+        - "TENANT_KVS"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/CustomField"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/allTags:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve account tags"
+      description: ""
+      operationId: "getAllTags"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "objectType"
+        in: "query"
+        required: false
+        type: "string"
+        enum:
+        - "ACCOUNT"
+        - "ACCOUNT_EMAIL"
+        - "BLOCKING_STATES"
+        - "BUNDLE"
+        - "CUSTOM_FIELD"
+        - "INVOICE"
+        - "PAYMENT"
+        - "TRANSACTION"
+        - "INVOICE_ITEM"
+        - "INVOICE_PAYMENT"
+        - "SUBSCRIPTION"
+        - "SUBSCRIPTION_EVENT"
+        - "SERVICE_BROADCAST"
+        - "PAYMENT_ATTEMPT"
+        - "PAYMENT_METHOD"
+        - "TAG"
+        - "TAG_DEFINITION"
+        - "TENANT"
+        - "TENANT_KVS"
+      - name: "includedDeleted"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Tag"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/block/{blockingId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve blocking state audit logs with history by id"
+      description: ""
+      operationId: "getBlockingStateAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "blockingId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Blocking state  not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/invoices:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve account invoices"
+      description: ""
+      operationId: "getInvoicesForAccount"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "startDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "endDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "withMigrationInvoices"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "unpaidInvoicesOnly"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "includeVoidedInvoices"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "invoicesFilter"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Invoice"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/overdue:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve overdue state for account"
+      description: ""
+      operationId: "getOverdueAccount"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/OverdueState"
+        "400":
+          description: "Invalid account id supplied"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/accounts/{accountId}/payments:
     get:
       tags:
@@ -1026,366 +1962,40 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/block:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve blocking states for account"
-      description: ""
-      operationId: "getBlockingStates"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "blockingStateTypes"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-          enum:
-          - "SUBSCRIPTION"
-          - "SUBSCRIPTION_BUNDLE"
-          - "ACCOUNT"
-        collectionFormat: "multi"
-      - name: "blockingStateSvcs"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/BlockingState"
-        "400":
-          description: "Invalid account id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
+  /1.0/kb/accounts/payments:
     post:
       tags:
       - "Account"
-      summary: "Block an account"
+      summary: "Trigger a payment using the account external key (authorization, purchase\
+        \ or credit)"
       description: ""
-      operationId: "addAccountBlockingState"
+      operationId: "processPaymentByExternalKey"
       consumes:
       - "application/json"
+      produces:
+      - "application/json"
       parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
       - in: "body"
         name: "body"
         required: true
         schema:
-          $ref: "#/definitions/BlockingState"
-      - name: "requestedDate"
+          $ref: "#/definitions/PaymentTransaction"
+      - name: "externalKey"
         in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
         required: true
         type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Blocking state created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/BlockingState"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve an account by id"
-      description: ""
-      operationId: "getAccount"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "accountWithBalance"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "accountWithBalanceAndCBA"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Account"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    put:
-      tags:
-      - "Account"
-      summary: "Update account"
-      description: ""
-      operationId: "updateAccount"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/Account"
-      - name: "treatNullAsReset"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid account data supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    delete:
-      tags:
-      - "Account"
-      summary: "Close account"
-      description: ""
-      operationId: "closeAccount"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "cancelAllSubscriptions"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "writeOffUnpaidInvoices"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "itemAdjustUnpaidInvoices"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "removeFutureNotifications"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: true
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid account id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/invoicePayments:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve account invoice payments"
-      description: ""
-      operationId: "getInvoicePayments"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "withPluginInfo"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "withAttempts"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/InvoicePayment"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Account"
-      summary: "Trigger a payment for all unpaid invoices"
-      description: ""
-      operationId: "payAllInvoices"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
       - name: "paymentMethodId"
         in: "query"
         required: false
         type: "string"
         format: "uuid"
-      - name: "externalPayment"
+      - name: "controlPluginName"
         in: "query"
         required: false
-        type: "boolean"
-        default: false
-      - name: "paymentAmount"
-        in: "query"
-        required: false
-        type: "number"
-      - name: "targetDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       - name: "pluginProperty"
         in: "query"
         required: false
@@ -1407,672 +2017,95 @@ paths:
         type: "string"
       responses:
         "201":
-          description: "Successful operation"
+          description: "Payment transaction created successfully"
           schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Invoice"
+            $ref: "#/definitions/Payment"
+        "400":
+          description: "Invalid account external key supplied"
+        "404":
+          description: "Account not found"
+        "402":
+          description: "Transaction declined by gateway"
+        "422":
+          description: "Payment is aborted by a control plugin"
+        "502":
+          description: "Failed to submit payment transaction"
+        "503":
+          description: "Payment in unknown status, failed to receive gateway response"
+        "504":
+          description: "Payment operation timeout"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/cbaRebalancing:
+    put:
+      tags:
+      - "Account"
+      summary: "Rebalance account CBA"
+      description: ""
+      operationId: "rebalanceExistingCBAOnAccount"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
         "204":
-          description: "Nothing to pay"
-        "404":
-          description: "Invalid account id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/bundles:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve bundles for account"
-      description: ""
-      operationId: "getAccountBundles"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "externalKey"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "bundlesFilter"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Bundle"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/allCustomFields:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve account customFields"
-      description: ""
-      operationId: "getAllCustomFields"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "objectType"
-        in: "query"
-        required: false
-        type: "string"
-        enum:
-        - "ACCOUNT"
-        - "ACCOUNT_EMAIL"
-        - "BLOCKING_STATES"
-        - "BUNDLE"
-        - "CUSTOM_FIELD"
-        - "INVOICE"
-        - "PAYMENT"
-        - "TRANSACTION"
-        - "INVOICE_ITEM"
-        - "INVOICE_PAYMENT"
-        - "SUBSCRIPTION"
-        - "SUBSCRIPTION_EVENT"
-        - "SERVICE_BROADCAST"
-        - "PAYMENT_ATTEMPT"
-        - "PAYMENT_METHOD"
-        - "TAG"
-        - "TAG_DEFINITION"
-        - "TENANT"
-        - "TENANT_KVS"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/CustomField"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/timeline:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve account timeline"
-      description: ""
-      operationId: "getAccountTimeline"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "parallel"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AccountTimeline"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/overdue:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve overdue state for account"
-      description: ""
-      operationId: "getOverdueAccount"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/OverdueState"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/allTags:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve account tags"
-      description: ""
-      operationId: "getAllTags"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "objectType"
-        in: "query"
-        required: false
-        type: "string"
-        enum:
-        - "ACCOUNT"
-        - "ACCOUNT_EMAIL"
-        - "BLOCKING_STATES"
-        - "BUNDLE"
-        - "CUSTOM_FIELD"
-        - "INVOICE"
-        - "PAYMENT"
-        - "TRANSACTION"
-        - "INVOICE_ITEM"
-        - "INVOICE_PAYMENT"
-        - "SUBSCRIPTION"
-        - "SUBSCRIPTION_EVENT"
-        - "SERVICE_BROADCAST"
-        - "PAYMENT_ATTEMPT"
-        - "PAYMENT_METHOD"
-        - "TAG"
-        - "TAG_DEFINITION"
-        - "TENANT"
-        - "TENANT_KVS"
-      - name: "includedDeleted"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Tag"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve an account by external key"
-      description: ""
-      operationId: "getAccountByKey"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "externalKey"
-        in: "query"
-        required: true
-        type: "string"
-      - name: "accountWithBalance"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "accountWithBalanceAndCBA"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Account"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Account"
-      summary: "Create account"
-      description: ""
-      operationId: "createAccount"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/Account"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Account created successfully"
-          schema:
-            $ref: "#/definitions/Account"
-        "400":
-          description: "Invalid account data supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/emails:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve an account emails"
-      description: ""
-      operationId: "getEmails"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AccountEmail"
+          description: "Successful operation"
         "400":
           description: "Invalid account id supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-    post:
+  /1.0/kb/admin/healthcheck:
+    put:
       tags:
-      - "Account"
-      summary: "Add account email"
+      - "Admin"
+      summary: "Put the host back into rotation"
       description: ""
-      operationId: "addEmail"
-      consumes:
-      - "application/json"
+      operationId: "putInRotation"
       produces:
       - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/AccountEmail"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
+      parameters: []
       responses:
-        "201":
-          description: "Email created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AccountEmail"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
+        "204":
+          description: "Successful operation"
       security:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/accounts/search/{searchKey}:
-    get:
-      tags:
-      - "Account"
-      summary: "Search accounts"
-      description: ""
-      operationId: "searchAccounts"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "searchKey"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int64"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 100
-        format: "int64"
-      - name: "accountWithBalance"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "accountWithBalanceAndCBA"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Account"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/pagination:
-    get:
-      tags:
-      - "Account"
-      summary: "List accounts"
-      description: ""
-      operationId: "getAccounts"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int64"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 100
-        format: "int64"
-      - name: "accountWithBalance"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "accountWithBalanceAndCBA"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Account"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/emails/{email}:
     delete:
       tags:
-      - "Account"
-      summary: "Delete email from account"
+      - "Admin"
+      summary: "Put the host out of rotation"
       description: ""
-      operationId: "removeEmail"
+      operationId: "putOutOfRotation"
       produces:
       - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "email"
-        in: "path"
-        required: true
-        type: "string"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
+      parameters: []
       responses:
         "204":
           description: "Successful operation"
-        "400":
-          description: "Invalid account id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/auditLogs:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve audit logs by account id"
-      description: ""
-      operationId: "getAccountAuditLogs"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/emails/{accountEmailId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve account email audit logs with history by id"
-      description: ""
-      operationId: "getAccountEmailAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "accountEmailId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/block/{blockingId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve blocking state audit logs with history by id"
-      description: ""
-      operationId: "getBlockingStateAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "blockingId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Blocking state  not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -2188,56 +2221,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/admin/payments/{paymentId}/transactions/{paymentTransactionId}:
-    put:
-      tags:
-      - "Admin"
-      summary: "Update existing paymentTransaction and associated payment state"
-      description: ""
-      operationId: "updatePaymentTransactionState"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "paymentTransactionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/AdminPayment"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid account data supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/admin/cache/tenants:
     delete:
       tags:
@@ -2245,39 +2228,6 @@ paths:
       summary: "Invalidates Caches per tenant level"
       description: ""
       operationId: "invalidatesCacheByTenant"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "204":
-          description: "Successful operation"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/admin/healthcheck:
-    put:
-      tags:
-      - "Admin"
-      summary: "Put the host back into rotation"
-      description: ""
-      operationId: "putInRotation"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "204":
-          description: "Successful operation"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    delete:
-      tags:
-      - "Admin"
-      summary: "Put the host out of rotation"
-      description: ""
-      operationId: "putOutOfRotation"
       produces:
       - "application/json"
       parameters: []
@@ -2334,6 +2284,56 @@ paths:
       responses:
         "200":
           description: "Successful operation"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/admin/payments/{paymentId}/transactions/{paymentTransactionId}:
+    put:
+      tags:
+      - "Admin"
+      summary: "Update existing paymentTransaction and associated payment state"
+      description: ""
+      operationId: "updatePaymentTransactionState"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "paymentTransactionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/AdminPayment"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid account data supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -2445,14 +2445,60 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/bundles/{bundleId}/block:
+  /1.0/kb/bundles/{bundleId}/tags:
+    get:
+      tags:
+      - "Bundle"
+      summary: "Retrieve bundle tags"
+      description: ""
+      operationId: "getBundleTags"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "bundleId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "includedDeleted"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Tag"
+        "400":
+          description: "Invalid bundle id supplied"
+        "404":
+          description: "Bundle not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
     post:
       tags:
       - "Bundle"
-      summary: "Block a bundle"
+      summary: "Add tags to bundle"
       description: ""
-      operationId: "addBundleBlockingState"
+      operationId: "createBundleTags"
       consumes:
+      - "application/json"
+      produces:
       - "application/json"
       parameters:
       - name: "bundleId"
@@ -2465,19 +2511,10 @@ paths:
         name: "body"
         required: true
         schema:
-          $ref: "#/definitions/BlockingState"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
+          type: "array"
+          items:
+            type: "string"
+            format: "uuid"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -2492,15 +2529,59 @@ paths:
         type: "string"
       responses:
         "201":
-          description: "Blocking state created successfully"
+          description: "Tag created successfully"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/BlockingState"
+              $ref: "#/definitions/Tag"
         "400":
           description: "Invalid bundle id supplied"
-        "404":
-          description: "Bundle not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    delete:
+      tags:
+      - "Bundle"
+      summary: "Remove tags from bundle"
+      description: ""
+      operationId: "deleteBundleTags"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "bundleId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "tagDef"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+          format: "uuid"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid bundle id supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -2683,176 +2764,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/bundles/{bundleId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Bundle"
-      summary: "Retrieve bundle audit logs with history by id"
-      description: ""
-      operationId: "getBundleAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "bundleId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Subscription bundle not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/bundles/{bundleId}/tags:
-    get:
-      tags:
-      - "Bundle"
-      summary: "Retrieve bundle tags"
-      description: ""
-      operationId: "getBundleTags"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "bundleId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "includedDeleted"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Tag"
-        "400":
-          description: "Invalid bundle id supplied"
-        "404":
-          description: "Bundle not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Bundle"
-      summary: "Add tags to bundle"
-      description: ""
-      operationId: "createBundleTags"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "bundleId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            type: "string"
-            format: "uuid"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Tag created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Tag"
-        "400":
-          description: "Invalid bundle id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    delete:
-      tags:
-      - "Bundle"
-      summary: "Remove tags from bundle"
-      description: ""
-      operationId: "deleteBundleTags"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "bundleId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "tagDef"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-          format: "uuid"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid bundle id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/bundles/pagination:
     get:
       tags:
@@ -2895,13 +2806,13 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/bundles/{bundleId}/renameKey:
-    put:
+  /1.0/kb/bundles/{bundleId}/block:
+    post:
       tags:
       - "Bundle"
-      summary: "Update a bundle externalKey"
+      summary: "Block a bundle"
       description: ""
-      operationId: "renameExternalKey"
+      operationId: "addBundleBlockingState"
       consumes:
       - "application/json"
       parameters:
@@ -2915,7 +2826,19 @@ paths:
         name: "body"
         required: true
         schema:
-          $ref: "#/definitions/Bundle"
+          $ref: "#/definitions/BlockingState"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -2929,12 +2852,45 @@ paths:
         required: false
         type: "string"
       responses:
-        "204":
-          description: "Successful operation"
+        "201":
+          description: "Blocking state created successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/BlockingState"
         "400":
-          description: "Invalid argumnent supplied"
+          description: "Invalid bundle id supplied"
         "404":
           description: "Bundle not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/bundles/{bundleId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Bundle"
+      summary: "Retrieve bundle audit logs with history by id"
+      description: ""
+      operationId: "getBundleAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "bundleId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Subscription bundle not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -3027,6 +2983,50 @@ paths:
           description: "Successful operation"
         "400":
           description: "Invalid bundle id supplied"
+        "404":
+          description: "Bundle not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/bundles/{bundleId}/renameKey:
+    put:
+      tags:
+      - "Bundle"
+      summary: "Update a bundle externalKey"
+      description: ""
+      operationId: "renameExternalKey"
+      consumes:
+      - "application/json"
+      parameters:
+      - name: "bundleId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Bundle"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid argumnent supplied"
         "404":
           description: "Bundle not found"
       security:
@@ -3133,218 +3133,23 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/catalog/availableBasePlans:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve available base plans"
-      description: ""
-      operationId: "getAvailableBasePlans"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/PlanDetail"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/product:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve product for a given subscription and date"
-      description: ""
-      operationId: "getProductForSubscriptionAndDate"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Product"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/phase:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve phase for a given subscription and date"
-      description: ""
-      operationId: "getPhaseForSubscriptionAndDate"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Phase"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/priceList:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve priceList for a given subscription and date"
-      description: ""
-      operationId: "getPriceListForSubscriptionAndDate"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/PriceList"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/plan:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve plan for a given subscription and date"
-      description: ""
-      operationId: "getPlanForSubscriptionAndDate"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Plan"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/versions:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve a list of catalog versions"
-      description: ""
-      operationId: "getCatalogVersions"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-              format: "date-time"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/xml:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve the full catalog as XML"
-      description: ""
-      operationId: "getCatalogXml"
-      produces:
-      - "text/xml"
-      parameters:
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date-time"
-      - name: "accountId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
+  /1.0/kb/catalog/simplePlan:
     post:
       tags:
       - "Catalog"
-      summary: "Upload the full catalog as XML"
+      summary: "Add a simple plan entry in the current version of the catalog"
       description: ""
-      operationId: "uploadCatalogXml"
+      operationId: "addSimplePlan"
       consumes:
-      - "text/xml"
+      - "application/json"
+      produces:
+      - "application/json"
       parameters:
       - in: "body"
         name: "body"
         required: true
         schema:
-          type: "string"
+          $ref: "#/definitions/SimplePlan"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -3359,7 +3164,7 @@ paths:
         type: "string"
       responses:
         "201":
-          description: "Catalog XML created successfully"
+          description: "Created new plan successfully"
           schema:
             type: "string"
       security:
@@ -3457,23 +3262,102 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/catalog/simplePlan:
+  /1.0/kb/catalog/availableBasePlans:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve available base plans"
+      description: ""
+      operationId: "getAvailableBasePlans"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/PlanDetail"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/versions:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve a list of catalog versions"
+      description: ""
+      operationId: "getCatalogVersions"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+              format: "date-time"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/xml:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve the full catalog as XML"
+      description: ""
+      operationId: "getCatalogXml"
+      produces:
+      - "text/xml"
+      parameters:
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date-time"
+      - name: "accountId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
     post:
       tags:
       - "Catalog"
-      summary: "Add a simple plan entry in the current version of the catalog"
+      summary: "Upload the full catalog as XML"
       description: ""
-      operationId: "addSimplePlan"
+      operationId: "uploadCatalogXml"
       consumes:
-      - "application/json"
-      produces:
-      - "application/json"
+      - "text/xml"
       parameters:
       - in: "body"
         name: "body"
         required: true
         schema:
-          $ref: "#/definitions/SimplePlan"
+          type: "string"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -3488,38 +3372,125 @@ paths:
         type: "string"
       responses:
         "201":
-          description: "Created new plan successfully"
+          description: "Catalog XML created successfully"
           schema:
             type: "string"
       security:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/credits/{creditId}:
+  /1.0/kb/catalog/phase:
     get:
       tags:
-      - "Credit"
-      summary: "Retrieve a credit by id"
+      - "Catalog"
+      summary: "Retrieve phase for a given subscription and date"
       description: ""
-      operationId: "getCredit"
+      operationId: "getPhaseForSubscriptionAndDate"
       produces:
       - "application/json"
       parameters:
-      - name: "creditId"
-        in: "path"
-        required: true
+      - name: "subscriptionId"
+        in: "query"
+        required: false
         type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
         format: "uuid"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/InvoiceItem"
-        "400":
-          description: "Invalid credit id supplied"
-        "404":
-          description: "Credit not found"
+            $ref: "#/definitions/Phase"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/plan:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve plan for a given subscription and date"
+      description: ""
+      operationId: "getPlanForSubscriptionAndDate"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Plan"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/priceList:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve priceList for a given subscription and date"
+      description: ""
+      operationId: "getPriceListForSubscriptionAndDate"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/PriceList"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/product:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve product for a given subscription and date"
+      description: ""
+      operationId: "getProductForSubscriptionAndDate"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Product"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -3582,28 +3553,92 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/customFields/search:
+  /1.0/kb/credits/{creditId}:
     get:
       tags:
-      - "CustomField"
-      summary: "Search custom fields by type, name and optional value"
+      - "Credit"
+      summary: "Retrieve a credit by id"
       description: ""
-      operationId: "searchCustomFieldsByTypeName"
+      operationId: "getCredit"
       produces:
       - "application/json"
       parameters:
-      - name: "objectType"
+      - name: "creditId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/InvoiceItem"
+        "400":
+          description: "Invalid credit id supplied"
+        "404":
+          description: "Credit not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/customFields/search/{searchKey}:
+    get:
+      tags:
+      - "CustomField"
+      summary: "Search custom fields"
+      description: ""
+      operationId: "searchCustomFields"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "searchKey"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int64"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 100
+        format: "int64"
+      - name: "audit"
         in: "query"
         required: false
         type: "string"
-      - name: "fieldName"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "fieldValue"
-        in: "query"
-        required: false
-        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/CustomField"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/customFields/pagination:
+    get:
+      tags:
+      - "CustomField"
+      summary: "List custom fields"
+      description: ""
+      operationId: "getCustomFields"
+      produces:
+      - "application/json"
+      parameters:
       - name: "offset"
         in: "query"
         required: false
@@ -3665,63 +3700,28 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/customFields/pagination:
+  /1.0/kb/customFields/search:
     get:
       tags:
       - "CustomField"
-      summary: "List custom fields"
+      summary: "Search custom fields by type, name and optional value"
       description: ""
-      operationId: "getCustomFields"
+      operationId: "searchCustomFieldsByTypeName"
       produces:
       - "application/json"
       parameters:
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int64"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 100
-        format: "int64"
-      - name: "audit"
+      - name: "objectType"
         in: "query"
         required: false
         type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/CustomField"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/customFields/search/{searchKey}:
-    get:
-      tags:
-      - "CustomField"
-      summary: "Search custom fields"
-      description: ""
-      operationId: "searchCustomFields"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "searchKey"
-        in: "path"
-        required: true
+      - name: "fieldName"
+        in: "query"
+        required: false
         type: "string"
-        pattern: ".*"
+      - name: "fieldValue"
+        in: "query"
+        required: false
+        type: "string"
       - name: "offset"
         in: "query"
         required: false
@@ -4294,6 +4294,61 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/invoicePayments/{paymentId}/chargebacks:
+    post:
+      tags:
+      - "InvoicePayment"
+      summary: "Record a chargeback"
+      description: ""
+      operationId: "createChargeback"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/InvoicePaymentTransaction"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Created chargeback successfully"
+          schema:
+            $ref: "#/definitions/InvoicePayment"
+        "400":
+          description: "Invalid payment id supplied"
+        "404":
+          description: "Account or payment not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/invoicePayments/{paymentId}/chargebackReversals:
     post:
       tags:
@@ -4469,61 +4524,6 @@ paths:
           description: "Payment in unknown status, failed to receive gateway response"
         "504":
           description: "Payment operation timeout"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoicePayments/{paymentId}/chargebacks:
-    post:
-      tags:
-      - "InvoicePayment"
-      summary: "Record a chargeback"
-      description: ""
-      operationId: "createChargeback"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/InvoicePaymentTransaction"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Created chargeback successfully"
-          schema:
-            $ref: "#/definitions/InvoicePayment"
-        "400":
-          description: "Invalid payment id supplied"
-        "404":
-          description: "Account or payment not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -4800,6 +4800,591 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/invoices/{invoiceId}/tags:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Retrieve invoice tags"
+      description: ""
+      operationId: "getInvoiceTags"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "includedDeleted"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Tag"
+        "400":
+          description: "Invalid invoice id supplied"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Invoice"
+      summary: "Add tags to invoice"
+      description: ""
+      operationId: "createInvoiceTags"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            type: "string"
+            format: "uuid"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Tag created successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Tag"
+        "400":
+          description: "Invalid invoice id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    delete:
+      tags:
+      - "Invoice"
+      summary: "Remove tags from invoice"
+      description: ""
+      operationId: "deleteInvoiceTags"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "tagDef"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+          format: "uuid"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid invoice id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/pagination:
+    get:
+      tags:
+      - "Invoice"
+      summary: "List invoices"
+      description: ""
+      operationId: "getInvoices"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int64"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 100
+        format: "int64"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Invoice"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/search/{searchKey}:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Search invoices"
+      description: ""
+      operationId: "searchInvoices"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "searchKey"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int64"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 100
+        format: "int64"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Invoice"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/{invoiceId}:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Retrieve an invoice by id"
+      description: ""
+      operationId: "getInvoice"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "withChildrenItems"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Invoice"
+        "400":
+          description: "Invalid invoice id supplied"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Invoice"
+      summary: "Adjust an invoice item"
+      description: ""
+      operationId: "adjustInvoiceItem"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/InvoiceItem"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Created adjustment Successfully"
+          schema:
+            $ref: "#/definitions/Invoice"
+        "400":
+          description: "Invalid account id, invoice id or invoice item id supplied"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/byNumber/{invoiceNumber}:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Retrieve an invoice by number"
+      description: ""
+      operationId: "getInvoiceByNumber"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceNumber"
+        in: "path"
+        required: true
+        type: "integer"
+        pattern: "[0-9]+"
+        format: "int32"
+      - name: "withChildrenItems"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Invoice"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/{invoiceId}/{invoiceItemId}/cba:
+    delete:
+      tags:
+      - "Invoice"
+      summary: "Delete a CBA item"
+      description: ""
+      operationId: "deleteCBA"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "invoiceItemId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "accountId"
+        in: "query"
+        required: true
+        type: "string"
+        format: "uuid"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid account id, invoice id or invoice item id supplied"
+        "404":
+          description: "Account or invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/{invoiceId}/html:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Render an invoice as HTML"
+      description: ""
+      operationId: "getInvoiceAsHTML"
+      produces:
+      - "text/html"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/{invoiceId}/commitInvoice:
+    put:
+      tags:
+      - "Invoice"
+      summary: "Perform the invoice status transition from DRAFT to COMMITTED"
+      description: ""
+      operationId: "commitInvoice"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/migration/{accountId}:
+    post:
+      tags:
+      - "Invoice"
+      summary: "Create a migration invoice"
+      description: ""
+      operationId: "createMigrationInvoice"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/InvoiceItem"
+      - name: "targetDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Created migration invoice successfully"
+          schema:
+            $ref: "#/definitions/Invoice"
+        "400":
+          description: "Invalid account id or target datetime supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/{invoiceId}/voidInvoice:
+    put:
+      tags:
+      - "Invoice"
+      summary: "Perform the action of voiding an invoice"
+      description: ""
+      operationId: "voidInvoice"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid invoice id supplied"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/invoices/{invoiceId}/customFields:
     get:
       tags:
@@ -4978,334 +5563,87 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/invoices/catalogTranslation/{locale}:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Retrieves the catalog translation for the tenant"
-      description: ""
-      operationId: "getCatalogTranslation"
-      produces:
-      - "text/plain"
-      parameters:
-      - name: "locale"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-        "400":
-          description: "Invalid locale supplied"
-        "404":
-          description: "Template not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
+  /1.0/kb/invoices/charges/{accountId}:
     post:
       tags:
       - "Invoice"
-      summary: "Upload the catalog translation for the tenant"
+      summary: "Create external charge(s)"
       description: ""
-      operationId: "uploadCatalogTranslation"
+      operationId: "createExternalCharges"
       consumes:
-      - "text/plain"
-      produces:
-      - "text/plain"
-      parameters:
-      - name: "locale"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "string"
-      - name: "deleteIfExists"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Uploaded catalog translation Successfully"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/manualPayTemplate:
-    post:
-      tags:
-      - "Invoice"
-      summary: "Upload the manualPay invoice template for the tenant"
-      description: ""
-      operationId: "uploadInvoiceMPTemplate"
-      consumes:
-      - "text/html"
-      produces:
-      - "text/html"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "string"
-      - name: "deleteIfExists"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/translation/{locale}:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Retrieves the invoice translation for the tenant"
-      description: ""
-      operationId: "getInvoiceTranslation"
-      produces:
-      - "text/plain"
-      parameters:
-      - name: "locale"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-        "400":
-          description: "Invalid locale supplied"
-        "404":
-          description: "Translation not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Invoice"
-      summary: "Upload the invoice translation for the tenant"
-      description: ""
-      operationId: "uploadInvoiceTranslation"
-      consumes:
-      - "text/plain"
-      produces:
-      - "text/plain"
-      parameters:
-      - name: "locale"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "string"
-      - name: "deleteIfExists"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Uploaded invoice translation Successfully"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/template:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Retrieves the invoice template for the tenant"
-      description: ""
-      operationId: "getInvoiceTemplate"
-      produces:
-      - "text/html"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-        "404":
-          description: "Template not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Invoice"
-      summary: "Upload the invoice template for the tenant"
-      description: ""
-      operationId: "uploadInvoiceTemplate"
-      consumes:
-      - "text/html"
-      produces:
-      - "text/html"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "string"
-      - name: "deleteIfExists"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Uploaded invoice template Successfully"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/manualPayTemplate/{locale}:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Retrieves the manualPay invoice template for the tenant"
-      description: ""
-      operationId: "getInvoiceMPTemplate"
-      produces:
-      - "text/html"
-      parameters:
-      - name: "locale"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-        "404":
-          description: "Template not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/{invoiceId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Retrieve invoice audit logs with history by id"
-      description: ""
-      operationId: "getInvoiceAuditLogsWithHistory"
+      - "application/json"
       produces:
       - "application/json"
       parameters:
-      - name: "invoiceId"
+      - name: "accountId"
         in: "path"
         required: true
         type: "string"
         pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
         format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/InvoiceItem"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "autoCommit"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
       responses:
-        "200":
-          description: "successful operation"
+        "201":
+          description: "Created external charge Successfully"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/AuditLog"
+              $ref: "#/definitions/InvoiceItem"
+        "400":
+          description: "Invalid account id supplied"
         "404":
-          description: "Invoice not found"
+          description: "Account not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/invoices/dryRun:
+  /1.0/kb/invoices:
     post:
       tags:
       - "Invoice"
-      summary: "Generate a dryRun invoice"
+      summary: "Trigger an invoice generation"
       description: ""
-      operationId: "generateDryRunInvoice"
+      operationId: "createFutureInvoice"
       consumes:
       - "application/json"
       produces:
       - "application/json"
       parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/InvoiceDryRun"
       - name: "accountId"
         in: "query"
         required: true
@@ -5336,12 +5674,64 @@ paths:
         required: false
         type: "string"
       responses:
-        "200":
-          description: "successful operation"
+        "201":
+          description: "Created invoice successfully"
           schema:
             $ref: "#/definitions/Invoice"
-        "204":
-          description: "Nothing to generate"
+        "400":
+          description: "Invalid account id or target datetime supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/group:
+    post:
+      tags:
+      - "Invoice"
+      summary: "Trigger an invoice generation"
+      description: ""
+      operationId: "createFutureInvoiceGroup"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "query"
+        required: true
+        type: "string"
+        format: "uuid"
+      - name: "targetDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Created invoice successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Invoice"
         "400":
           description: "Invalid account id or target datetime supplied"
       security:
@@ -5466,375 +5856,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/invoices/{invoiceId}/tags:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Retrieve invoice tags"
-      description: ""
-      operationId: "getInvoiceTags"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoiceId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "includedDeleted"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Tag"
-        "400":
-          description: "Invalid invoice id supplied"
-        "404":
-          description: "Invoice not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Invoice"
-      summary: "Add tags to invoice"
-      description: ""
-      operationId: "createInvoiceTags"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoiceId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            type: "string"
-            format: "uuid"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Tag created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Tag"
-        "400":
-          description: "Invalid invoice id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    delete:
-      tags:
-      - "Invoice"
-      summary: "Remove tags from invoice"
-      description: ""
-      operationId: "deleteInvoiceTags"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoiceId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "tagDef"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-          format: "uuid"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid invoice id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/migration/{accountId}:
-    post:
-      tags:
-      - "Invoice"
-      summary: "Create a migration invoice"
-      description: ""
-      operationId: "createMigrationInvoice"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            $ref: "#/definitions/InvoiceItem"
-      - name: "targetDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Created migration invoice successfully"
-          schema:
-            $ref: "#/definitions/Invoice"
-        "400":
-          description: "Invalid account id or target datetime supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/group:
-    post:
-      tags:
-      - "Invoice"
-      summary: "Trigger an invoice generation"
-      description: ""
-      operationId: "createFutureInvoiceGroup"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "query"
-        required: true
-        type: "string"
-        format: "uuid"
-      - name: "targetDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Created invoice successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Invoice"
-        "400":
-          description: "Invalid account id or target datetime supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices:
-    post:
-      tags:
-      - "Invoice"
-      summary: "Trigger an invoice generation"
-      description: ""
-      operationId: "createFutureInvoice"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "query"
-        required: true
-        type: "string"
-        format: "uuid"
-      - name: "targetDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Created invoice successfully"
-          schema:
-            $ref: "#/definitions/Invoice"
-        "400":
-          description: "Invalid account id or target datetime supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/charges/{accountId}:
-    post:
-      tags:
-      - "Invoice"
-      summary: "Create external charge(s)"
-      description: ""
-      operationId: "createExternalCharges"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            $ref: "#/definitions/InvoiceItem"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "autoCommit"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Created external charge Successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/InvoiceItem"
-        "400":
-          description: "Invalid account id supplied"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/invoices/taxes/{accountId}:
     post:
       tags:
@@ -5904,6 +5925,169 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/invoices/dryRun:
+    post:
+      tags:
+      - "Invoice"
+      summary: "Generate a dryRun invoice"
+      description: ""
+      operationId: "generateDryRunInvoice"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/InvoiceDryRun"
+      - name: "accountId"
+        in: "query"
+        required: true
+        type: "string"
+        format: "uuid"
+      - name: "targetDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Invoice"
+        "204":
+          description: "Nothing to generate"
+        "400":
+          description: "Invalid account id or target datetime supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/catalogTranslation/{locale}:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Retrieves the catalog translation for the tenant"
+      description: ""
+      operationId: "getCatalogTranslation"
+      produces:
+      - "text/plain"
+      parameters:
+      - name: "locale"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
+        "400":
+          description: "Invalid locale supplied"
+        "404":
+          description: "Template not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Invoice"
+      summary: "Upload the catalog translation for the tenant"
+      description: ""
+      operationId: "uploadCatalogTranslation"
+      consumes:
+      - "text/plain"
+      produces:
+      - "text/plain"
+      parameters:
+      - name: "locale"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "string"
+      - name: "deleteIfExists"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Uploaded catalog translation Successfully"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/{invoiceId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Retrieve invoice audit logs with history by id"
+      description: ""
+      operationId: "getInvoiceAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoiceId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Invoice not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/invoices/byItemId/{itemId}:
     get:
       tags:
@@ -5945,45 +6129,49 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/invoices/{invoiceId}:
+  /1.0/kb/invoices/manualPayTemplate/{locale}:
     get:
       tags:
       - "Invoice"
-      summary: "Retrieve an invoice by id"
+      summary: "Retrieves the manualPay invoice template for the tenant"
       description: ""
-      operationId: "getInvoice"
+      operationId: "getInvoiceMPTemplate"
       produces:
-      - "application/json"
+      - "text/html"
       parameters:
-      - name: "invoiceId"
+      - name: "locale"
         in: "path"
         required: true
         type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "withChildrenItems"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
+        pattern: ".*"
       responses:
         "200":
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Invoice"
-        "400":
-          description: "Invalid invoice id supplied"
+            type: "string"
         "404":
-          description: "Invoice not found"
+          description: "Template not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/template:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Retrieves the invoice template for the tenant"
+      description: ""
+      operationId: "getInvoiceTemplate"
+      produces:
+      - "text/html"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
+        "404":
+          description: "Template not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -5991,37 +6179,24 @@ paths:
     post:
       tags:
       - "Invoice"
-      summary: "Adjust an invoice item"
+      summary: "Upload the invoice template for the tenant"
       description: ""
-      operationId: "adjustInvoiceItem"
+      operationId: "uploadInvoiceTemplate"
       consumes:
-      - "application/json"
+      - "text/html"
       produces:
-      - "application/json"
+      - "text/html"
       parameters:
-      - name: "invoiceId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
       - in: "body"
         name: "body"
         required: true
         schema:
-          $ref: "#/definitions/InvoiceItem"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
           type: "string"
-        collectionFormat: "multi"
+      - name: "deleteIfExists"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -6036,13 +6211,84 @@ paths:
         type: "string"
       responses:
         "201":
-          description: "Created adjustment Successfully"
+          description: "Uploaded invoice template Successfully"
           schema:
-            $ref: "#/definitions/Invoice"
+            type: "string"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoices/translation/{locale}:
+    get:
+      tags:
+      - "Invoice"
+      summary: "Retrieves the invoice translation for the tenant"
+      description: ""
+      operationId: "getInvoiceTranslation"
+      produces:
+      - "text/plain"
+      parameters:
+      - name: "locale"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
         "400":
-          description: "Invalid account id, invoice id or invoice item id supplied"
+          description: "Invalid locale supplied"
         "404":
-          description: "Invoice not found"
+          description: "Translation not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Invoice"
+      summary: "Upload the invoice translation for the tenant"
+      description: ""
+      operationId: "uploadInvoiceTranslation"
+      consumes:
+      - "text/plain"
+      produces:
+      - "text/plain"
+      parameters:
+      - name: "locale"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "string"
+      - name: "deleteIfExists"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Uploaded invoice translation Successfully"
+          schema:
+            type: "string"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -6095,291 +6341,45 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/invoices/{invoiceId}/voidInvoice:
-    put:
+  /1.0/kb/invoices/manualPayTemplate:
+    post:
       tags:
       - "Invoice"
-      summary: "Perform the action of voiding an invoice"
+      summary: "Upload the manualPay invoice template for the tenant"
       description: ""
-      operationId: "voidInvoice"
+      operationId: "uploadInvoiceMPTemplate"
       consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoiceId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid invoice id supplied"
-        "404":
-          description: "Invoice not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/{invoiceId}/commitInvoice:
-    put:
-      tags:
-      - "Invoice"
-      summary: "Perform the invoice status transition from DRAFT to COMMITTED"
-      description: ""
-      operationId: "commitInvoice"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoiceId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "404":
-          description: "Invoice not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/{invoiceId}/{invoiceItemId}/cba:
-    delete:
-      tags:
-      - "Invoice"
-      summary: "Delete a CBA item"
-      description: ""
-      operationId: "deleteCBA"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoiceId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "invoiceItemId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "accountId"
-        in: "query"
-        required: true
-        type: "string"
-        format: "uuid"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid account id, invoice id or invoice item id supplied"
-        "404":
-          description: "Account or invoice not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/{invoiceId}/html:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Render an invoice as HTML"
-      description: ""
-      operationId: "getInvoiceAsHTML"
+      - "text/html"
       produces:
       - "text/html"
       parameters:
-      - name: "invoiceId"
-        in: "path"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "string"
+      - name: "deleteIfExists"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
         required: true
         type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
       responses:
         "200":
           description: "successful operation"
           schema:
             type: "string"
-        "404":
-          description: "Invoice not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/byNumber/{invoiceNumber}:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Retrieve an invoice by number"
-      description: ""
-      operationId: "getInvoiceByNumber"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoiceNumber"
-        in: "path"
-        required: true
-        type: "integer"
-        pattern: "[0-9]+"
-        format: "int32"
-      - name: "withChildrenItems"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Invoice"
-        "404":
-          description: "Invoice not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/pagination:
-    get:
-      tags:
-      - "Invoice"
-      summary: "List invoices"
-      description: ""
-      operationId: "getInvoices"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int64"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 100
-        format: "int64"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Invoice"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoices/search/{searchKey}:
-    get:
-      tags:
-      - "Invoice"
-      summary: "Search invoices"
-      description: ""
-      operationId: "searchInvoices"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "searchKey"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int64"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 100
-        format: "int64"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Invoice"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -6443,62 +6443,6 @@ paths:
           description: "Invalid node command supplied"
       security:
       - basicAuth: []
-  /1.0/kb/overdue/xml:
-    get:
-      tags:
-      - "Overdue"
-      summary: "Retrieve the overdue config as XML"
-      description: ""
-      operationId: "getOverdueConfigXml"
-      produces:
-      - "text/xml"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Overdue"
-      summary: "Upload the full overdue config as XML"
-      description: ""
-      operationId: "uploadOverdueConfigXml"
-      consumes:
-      - "text/xml"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "string"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Successfully uploaded overdue config"
-          schema:
-            type: "string"
-        "400":
-          description: "Invalid node command supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/overdue:
     get:
       tags:
@@ -6557,42 +6501,39 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/paymentGateways/notification/{pluginName}:
+  /1.0/kb/overdue/xml:
+    get:
+      tags:
+      - "Overdue"
+      summary: "Retrieve the overdue config as XML"
+      description: ""
+      operationId: "getOverdueConfigXml"
+      produces:
+      - "text/xml"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
     post:
       tags:
-      - "PaymentGateway"
-      summary: "Process a gateway notification"
-      description: "The response is built by the appropriate plugin"
-      operationId: "processNotification"
+      - "Overdue"
+      summary: "Upload the full overdue config as XML"
+      description: ""
+      operationId: "uploadOverdueConfigXml"
       consumes:
-      - "*/*"
-      produces:
-      - "application/json"
+      - "text/xml"
       parameters:
-      - name: "pluginName"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
       - in: "body"
         name: "body"
         required: true
         schema:
           type: "string"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -6606,8 +6547,12 @@ paths:
         required: false
         type: "string"
       responses:
-        "200":
-          description: "Successful"
+        "201":
+          description: "Successfully uploaded overdue config"
+          schema:
+            type: "string"
+        "400":
+          description: "Invalid node command supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -6677,6 +6622,61 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/paymentGateways/notification/{pluginName}:
+    post:
+      tags:
+      - "PaymentGateway"
+      summary: "Process a gateway notification"
+      description: "The response is built by the appropriate plugin"
+      operationId: "processNotification"
+      consumes:
+      - "*/*"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "pluginName"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "string"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "200":
+          description: "Successful"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/paymentGateways/hosted/form:
     post:
       tags:
@@ -6727,6 +6727,64 @@ paths:
             $ref: "#/definitions/HostedPaymentPageFormDescriptor"
         "400":
           description: "Invalid data for Account or PaymentMethod"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/paymentMethods/pagination:
+    get:
+      tags:
+      - "PaymentMethod"
+      summary: "List payment methods"
+      description: ""
+      operationId: "getPaymentMethods"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int64"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 100
+        format: "int64"
+      - name: "pluginName"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "withPluginInfo"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/PaymentMethod"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -7082,6 +7140,35 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/paymentMethods/{paymentMethodId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "PaymentMethod"
+      summary: "Retrieve payment method audit logs with history by id"
+      description: ""
+      operationId: "getPaymentMethodAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentMethodId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/paymentMethods:
     get:
       tags:
@@ -7129,93 +7216,6 @@ paths:
             $ref: "#/definitions/PaymentMethod"
         "404":
           description: "Account or payment method not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/paymentMethods/pagination:
-    get:
-      tags:
-      - "PaymentMethod"
-      summary: "List payment methods"
-      description: ""
-      operationId: "getPaymentMethods"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int64"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 100
-        format: "int64"
-      - name: "pluginName"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "withPluginInfo"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/PaymentMethod"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/paymentMethods/{paymentMethodId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "PaymentMethod"
-      summary: "Retrieve payment method audit logs with history by id"
-      description: ""
-      operationId: "getPaymentMethodAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentMethodId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Account not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -7357,35 +7357,6 @@ paths:
           description: "Successful operation"
         "400":
           description: "Invalid payment id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/payments/{paymentId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Payment"
-      summary: "Retrieve payment audit logs with history by id"
-      description: ""
-      operationId: "getPaymentAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Account not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -7654,312 +7625,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/payments/refunds:
-    post:
-      tags:
-      - "Payment"
-      summary: "Refund an existing payment"
-      description: ""
-      operationId: "refundPaymentByExternalKey"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentTransaction"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Payment transaction created successfully"
-          schema:
-            $ref: "#/definitions/Payment"
-        "404":
-          description: "Account or payment not found"
-        "402":
-          description: "Transaction declined by gateway"
-        "422":
-          description: "Payment is aborted by a control plugin"
-        "502":
-          description: "Failed to submit payment transaction"
-        "503":
-          description: "Payment in unknown status, failed to receive gateway response"
-        "504":
-          description: "Payment operation timeout"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/payments/{paymentId}/customFields:
-    get:
-      tags:
-      - "Payment"
-      summary: "Retrieve payment custom fields"
-      description: ""
-      operationId: "getPaymentCustomFields"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/CustomField"
-        "400":
-          description: "Invalid payment id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Payment"
-      summary: "Add custom fields to payment"
-      description: ""
-      operationId: "createPaymentCustomFields"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            $ref: "#/definitions/CustomField"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Custom field created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/CustomField"
-        "400":
-          description: "Invalid payment id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    put:
-      tags:
-      - "Payment"
-      summary: "Modify custom fields to payment"
-      description: ""
-      operationId: "modifyPaymentCustomFields"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            $ref: "#/definitions/CustomField"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid payment id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    delete:
-      tags:
-      - "Payment"
-      summary: "Remove custom fields from payment payment"
-      description: ""
-      operationId: "deletePaymentCustomFields"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "customField"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-          format: "uuid"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid payment id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/payments/chargebacks:
-    post:
-      tags:
-      - "Payment"
-      summary: "Record a chargeback"
-      description: ""
-      operationId: "chargebackPaymentByExternalKey"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentTransaction"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Payment transaction created successfully"
-          schema:
-            $ref: "#/definitions/Payment"
-        "404":
-          description: "Account or payment not found"
-        "402":
-          description: "Transaction declined by gateway"
-        "422":
-          description: "Payment is aborted by a control plugin"
-        "502":
-          description: "Failed to submit payment transaction"
-        "503":
-          description: "Payment in unknown status, failed to receive gateway response"
-        "504":
-          description: "Payment operation timeout"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/payments:
     get:
       tags:
@@ -8196,280 +7861,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/payments/{paymentId}/chargebackReversals:
-    post:
-      tags:
-      - "Payment"
-      summary: "Record a chargeback reversal"
-      description: ""
-      operationId: "chargebackReversalPayment"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentTransaction"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Payment transaction created successfully"
-          schema:
-            $ref: "#/definitions/Payment"
-        "400":
-          description: "Invalid paymentId supplied"
-        "404":
-          description: "Account or payment not found"
-        "402":
-          description: "Transaction declined by gateway"
-        "422":
-          description: "Payment is aborted by a control plugin"
-        "502":
-          description: "Failed to submit payment transaction"
-        "503":
-          description: "Payment in unknown status, failed to receive gateway response"
-        "504":
-          description: "Payment operation timeout"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/payments/combo:
-    post:
-      tags:
-      - "Payment"
-      summary: "Combo api to create a new payment transaction on a existing (or not)\
-        \ account "
-      description: ""
-      operationId: "createComboPayment"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/ComboPaymentTransaction"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Payment transaction created successfully"
-          schema:
-            $ref: "#/definitions/Payment"
-        "400":
-          description: "Invalid data for Account or PaymentMethod"
-        "402":
-          description: "Transaction declined by gateway"
-        "422":
-          description: "Payment is aborted by a control plugin"
-        "502":
-          description: "Failed to submit payment transaction"
-        "503":
-          description: "Payment in unknown status, failed to receive gateway response"
-        "504":
-          description: "Payment operation timeout"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/payments/{paymentId}/chargebacks:
-    post:
-      tags:
-      - "Payment"
-      summary: "Record a chargeback"
-      description: ""
-      operationId: "chargebackPayment"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentTransaction"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Payment transaction created successfully"
-          schema:
-            $ref: "#/definitions/Payment"
-        "400":
-          description: "Invalid paymentId supplied"
-        "404":
-          description: "Account or payment not found"
-        "402":
-          description: "Transaction declined by gateway"
-        "422":
-          description: "Payment is aborted by a control plugin"
-        "502":
-          description: "Failed to submit payment transaction"
-        "503":
-          description: "Payment in unknown status, failed to receive gateway response"
-        "504":
-          description: "Payment operation timeout"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/payments/{paymentId}/refunds:
-    post:
-      tags:
-      - "Payment"
-      summary: "Refund an existing payment"
-      description: ""
-      operationId: "refundPayment"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentTransaction"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Payment transaction created successfully"
-          schema:
-            $ref: "#/definitions/Payment"
-        "400":
-          description: "Invalid paymentId supplied"
-        "404":
-          description: "Account or payment not found"
-        "402":
-          description: "Transaction declined by gateway"
-        "422":
-          description: "Payment is aborted by a control plugin"
-        "502":
-          description: "Failed to submit payment transaction"
-        "503":
-          description: "Payment in unknown status, failed to receive gateway response"
-        "504":
-          description: "Payment operation timeout"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/payments/pagination:
     get:
       tags:
@@ -8601,31 +7992,180 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/payments/attempts/{paymentAttemptId}/auditLogsWithHistory:
+  /1.0/kb/payments/{paymentId}/customFields:
     get:
       tags:
       - "Payment"
-      summary: "Retrieve payment attempt audit logs with history by id"
+      summary: "Retrieve payment custom fields"
       description: ""
-      operationId: "getPaymentAttemptAuditLogsWithHistory"
+      operationId: "getPaymentCustomFields"
       produces:
       - "application/json"
       parameters:
-      - name: "paymentAttemptId"
+      - name: "paymentId"
         in: "path"
         required: true
         type: "string"
         pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
         format: "uuid"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
       responses:
         "200":
           description: "successful operation"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Account not found"
+              $ref: "#/definitions/CustomField"
+        "400":
+          description: "Invalid payment id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Payment"
+      summary: "Add custom fields to payment"
+      description: ""
+      operationId: "createPaymentCustomFields"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/CustomField"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Custom field created successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/CustomField"
+        "400":
+          description: "Invalid payment id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    put:
+      tags:
+      - "Payment"
+      summary: "Modify custom fields to payment"
+      description: ""
+      operationId: "modifyPaymentCustomFields"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/CustomField"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid payment id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    delete:
+      tags:
+      - "Payment"
+      summary: "Remove custom fields from payment payment"
+      description: ""
+      operationId: "deletePaymentCustomFields"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "customField"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+          format: "uuid"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid payment id supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -8663,6 +8203,253 @@ paths:
           description: "Successful operation"
         "400":
           description: "Invalid paymentTransactionExternalKey supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/{paymentTransactionId}/cancelScheduledPaymentTransaction:
+    delete:
+      tags:
+      - "Payment"
+      summary: "Cancels a scheduled payment attempt retry"
+      description: ""
+      operationId: "cancelScheduledPaymentTransactionById"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentTransactionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid paymentTransactionId supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/{paymentId}/chargebacks:
+    post:
+      tags:
+      - "Payment"
+      summary: "Record a chargeback"
+      description: ""
+      operationId: "chargebackPayment"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/PaymentTransaction"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Payment transaction created successfully"
+          schema:
+            $ref: "#/definitions/Payment"
+        "400":
+          description: "Invalid paymentId supplied"
+        "404":
+          description: "Account or payment not found"
+        "402":
+          description: "Transaction declined by gateway"
+        "422":
+          description: "Payment is aborted by a control plugin"
+        "502":
+          description: "Failed to submit payment transaction"
+        "503":
+          description: "Payment in unknown status, failed to receive gateway response"
+        "504":
+          description: "Payment operation timeout"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/chargebacks:
+    post:
+      tags:
+      - "Payment"
+      summary: "Record a chargeback"
+      description: ""
+      operationId: "chargebackPaymentByExternalKey"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/PaymentTransaction"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Payment transaction created successfully"
+          schema:
+            $ref: "#/definitions/Payment"
+        "404":
+          description: "Account or payment not found"
+        "402":
+          description: "Transaction declined by gateway"
+        "422":
+          description: "Payment is aborted by a control plugin"
+        "502":
+          description: "Failed to submit payment transaction"
+        "503":
+          description: "Payment in unknown status, failed to receive gateway response"
+        "504":
+          description: "Payment operation timeout"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/{paymentId}/chargebackReversals:
+    post:
+      tags:
+      - "Payment"
+      summary: "Record a chargeback reversal"
+      description: ""
+      operationId: "chargebackReversalPayment"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/PaymentTransaction"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Payment transaction created successfully"
+          schema:
+            $ref: "#/definitions/Payment"
+        "400":
+          description: "Invalid paymentId supplied"
+        "404":
+          description: "Account or payment not found"
+        "402":
+          description: "Transaction declined by gateway"
+        "422":
+          description: "Payment is aborted by a control plugin"
+        "502":
+          description: "Failed to submit payment transaction"
+        "503":
+          description: "Payment in unknown status, failed to receive gateway response"
+        "504":
+          description: "Payment operation timeout"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -8731,24 +8518,31 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/payments/{paymentTransactionId}/cancelScheduledPaymentTransaction:
-    delete:
+  /1.0/kb/payments/combo:
+    post:
       tags:
       - "Payment"
-      summary: "Cancels a scheduled payment attempt retry"
+      summary: "Combo api to create a new payment transaction on a existing (or not)\
+        \ account "
       description: ""
-      operationId: "cancelScheduledPaymentTransactionById"
+      operationId: "createComboPayment"
       consumes:
       - "application/json"
       produces:
       - "application/json"
       parameters:
-      - name: "paymentTransactionId"
-        in: "path"
+      - in: "body"
+        name: "body"
         required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
+        schema:
+          $ref: "#/definitions/ComboPaymentTransaction"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -8762,10 +8556,216 @@ paths:
         required: false
         type: "string"
       responses:
-        "204":
-          description: "Successful operation"
+        "201":
+          description: "Payment transaction created successfully"
+          schema:
+            $ref: "#/definitions/Payment"
         "400":
-          description: "Invalid paymentTransactionId supplied"
+          description: "Invalid data for Account or PaymentMethod"
+        "402":
+          description: "Transaction declined by gateway"
+        "422":
+          description: "Payment is aborted by a control plugin"
+        "502":
+          description: "Failed to submit payment transaction"
+        "503":
+          description: "Payment in unknown status, failed to receive gateway response"
+        "504":
+          description: "Payment operation timeout"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/attempts/{paymentAttemptId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Payment"
+      summary: "Retrieve payment attempt audit logs with history by id"
+      description: ""
+      operationId: "getPaymentAttemptAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentAttemptId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/{paymentId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Payment"
+      summary: "Retrieve payment audit logs with history by id"
+      description: ""
+      operationId: "getPaymentAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/{paymentId}/refunds:
+    post:
+      tags:
+      - "Payment"
+      summary: "Refund an existing payment"
+      description: ""
+      operationId: "refundPayment"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/PaymentTransaction"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Payment transaction created successfully"
+          schema:
+            $ref: "#/definitions/Payment"
+        "400":
+          description: "Invalid paymentId supplied"
+        "404":
+          description: "Account or payment not found"
+        "402":
+          description: "Transaction declined by gateway"
+        "422":
+          description: "Payment is aborted by a control plugin"
+        "502":
+          description: "Failed to submit payment transaction"
+        "503":
+          description: "Payment in unknown status, failed to receive gateway response"
+        "504":
+          description: "Payment operation timeout"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/payments/refunds:
+    post:
+      tags:
+      - "Payment"
+      summary: "Refund an existing payment"
+      description: ""
+      operationId: "refundPaymentByExternalKey"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/PaymentTransaction"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Payment transaction created successfully"
+          schema:
+            $ref: "#/definitions/Payment"
+        "404":
+          description: "Account or payment not found"
+        "402":
+          description: "Transaction declined by gateway"
+        "422":
+          description: "Payment is aborted by a control plugin"
+        "502":
+          description: "Failed to submit payment transaction"
+        "503":
+          description: "Payment in unknown status, failed to receive gateway response"
+        "504":
+          description: "Payment operation timeout"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -8810,131 +8810,6 @@ paths:
               type: "string"
       security:
       - basicAuth: []
-  /1.0/kb/security/roles:
-    post:
-      tags:
-      - "Security"
-      summary: "Add a new role definition)"
-      description: ""
-      operationId: "addRoleDefinition"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/RoleDefinition"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Role definition created successfully"
-          schema:
-            $ref: "#/definitions/RoleDefinition"
-      security:
-      - basicAuth: []
-    put:
-      tags:
-      - "Security"
-      summary: "Update a new role definition)"
-      description: ""
-      operationId: "updateRoleDefinition"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/RoleDefinition"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-      security:
-      - basicAuth: []
-  /1.0/kb/security/subject:
-    get:
-      tags:
-      - "Security"
-      summary: "Get user information"
-      description: ""
-      operationId: "getCurrentUserSubject"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Subject"
-      security:
-      - basicAuth: []
-  /1.0/kb/security/users/{username}/password:
-    put:
-      tags:
-      - "Security"
-      summary: "Update a user password"
-      description: ""
-      operationId: "updateUserPassword"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "username"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/UserRoles"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-      security:
-      - basicAuth: []
   /1.0/kb/security/users:
     post:
       tags:
@@ -8971,13 +8846,13 @@ paths:
             $ref: "#/definitions/UserRoles"
       security:
       - basicAuth: []
-  /1.0/kb/security/users/{username}:
-    delete:
+  /1.0/kb/security/users/{username}/password:
+    put:
       tags:
       - "Security"
-      summary: "Invalidate an existing user"
+      summary: "Update a user password"
       description: ""
-      operationId: "invalidateUser"
+      operationId: "updateUserPassword"
       consumes:
       - "application/json"
       produces:
@@ -8988,6 +8863,11 @@ paths:
         required: true
         type: "string"
         pattern: ".*"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/UserRoles"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -9067,6 +8947,109 @@ paths:
           description: "Successful operation"
       security:
       - basicAuth: []
+  /1.0/kb/security/users/{username}:
+    delete:
+      tags:
+      - "Security"
+      summary: "Invalidate an existing user"
+      description: ""
+      operationId: "invalidateUser"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+      security:
+      - basicAuth: []
+  /1.0/kb/security/roles:
+    post:
+      tags:
+      - "Security"
+      summary: "Add a new role definition)"
+      description: ""
+      operationId: "addRoleDefinition"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/RoleDefinition"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Role definition created successfully"
+          schema:
+            $ref: "#/definitions/RoleDefinition"
+      security:
+      - basicAuth: []
+    put:
+      tags:
+      - "Security"
+      summary: "Update a new role definition)"
+      description: ""
+      operationId: "updateRoleDefinition"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/RoleDefinition"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+      security:
+      - basicAuth: []
   /1.0/kb/security/roles/{role}:
     get:
       tags:
@@ -9089,68 +9072,91 @@ paths:
             $ref: "#/definitions/RoleDefinition"
       security:
       - basicAuth: []
-  /1.0/kb/subscriptions/createSubscriptionWithAddOns:
+  /1.0/kb/security/subject:
+    get:
+      tags:
+      - "Security"
+      summary: "Get user information"
+      description: ""
+      operationId: "getCurrentUserSubject"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Subject"
+      security:
+      - basicAuth: []
+  /1.0/kb/subscriptions/{subscriptionId}/tags:
+    get:
+      tags:
+      - "Subscription"
+      summary: "Retrieve subscription tags"
+      description: ""
+      operationId: "getSubscriptionTags"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "includedDeleted"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Tag"
+        "400":
+          description: "Invalid subscription id supplied"
+        "404":
+          description: "Subscription not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
     post:
       tags:
       - "Subscription"
-      summary: "Create an entitlement with addOn products"
-      description: ""
-      operationId: "createSubscriptionWithAddOns"
+      operationId: "createSubscriptionTags"
       consumes:
       - "application/json"
       produces:
       - "application/json"
       parameters:
+      - name: "subscriptionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
       - in: "body"
         name: "body"
         required: true
         schema:
           type: "array"
           items:
-            $ref: "#/definitions/Subscription"
-      - name: "entitlementDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "billingDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "migrated"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "skipResponse"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "renameKeyIfExistsAndUnused"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: true
-      - name: "callCompletion"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "callTimeoutSec"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 3
-        format: "int64"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
+            type: "string"
+            format: "uuid"
       - name: "X-Killbill-CreatedBy"
         in: "header"
         required: true
@@ -9165,9 +9171,55 @@ paths:
         type: "string"
       responses:
         "201":
-          description: "Subscriptions created successfully"
-          schema:
-            $ref: "#/definitions/Bundle"
+          description: "Tag created successfully"
+        "400":
+          description: "Invalid subscription id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    delete:
+      tags:
+      - "Subscription"
+      summary: "Remove tags from subscription"
+      description: ""
+      operationId: "deleteSubscriptionTags"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "tagDef"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+          format: "uuid"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid subscription id supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -9346,14 +9398,14 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/subscriptions/{subscriptionId}/uncancel:
-    put:
+  /1.0/kb/subscriptions/{subscriptionId}/block:
+    post:
       tags:
       - "Subscription"
-      summary: "Un-cancel an entitlement"
+      summary: "Block a subscription"
       description: ""
-      operationId: "uncancelSubscriptionPlan"
-      produces:
+      operationId: "addSubscriptionBlockingState"
+      consumes:
       - "application/json"
       parameters:
       - name: "subscriptionId"
@@ -9362,6 +9414,16 @@ paths:
         type: "string"
         pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
         format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/BlockingState"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
       - name: "pluginProperty"
         in: "query"
         required: false
@@ -9382,147 +9444,16 @@ paths:
         required: false
         type: "string"
       responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid subscription id supplied"
-        "404":
-          description: "Entitlement not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/subscriptions/{subscriptionId}/tags:
-    get:
-      tags:
-      - "Subscription"
-      summary: "Retrieve subscription tags"
-      description: ""
-      operationId: "getSubscriptionTags"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "includedDeleted"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
+        "201":
+          description: "Blocking state created successfully"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Tag"
+              $ref: "#/definitions/BlockingState"
         "400":
           description: "Invalid subscription id supplied"
         "404":
           description: "Subscription not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Subscription"
-      operationId: "createSubscriptionTags"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            type: "string"
-            format: "uuid"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Tag created successfully"
-        "400":
-          description: "Invalid subscription id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    delete:
-      tags:
-      - "Subscription"
-      summary: "Remove tags from subscription"
-      description: ""
-      operationId: "deleteSubscriptionTags"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "tagDef"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-          format: "uuid"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid subscription id supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -9724,205 +9655,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/subscriptions/{subscriptionId}/bcd:
-    put:
-      tags:
-      - "Subscription"
-      summary: "Update the BCD associated to a subscription"
-      description: ""
-      operationId: "updateSubscriptionBCD"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/Subscription"
-      - name: "effectiveFromDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "forceNewBcdWithPastEffectiveDate"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid entitlement supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/subscriptions/{subscriptionId}/block:
-    post:
-      tags:
-      - "Subscription"
-      summary: "Block a subscription"
-      description: ""
-      operationId: "addSubscriptionBlockingState"
-      consumes:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/BlockingState"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Blocking state created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/BlockingState"
-        "400":
-          description: "Invalid subscription id supplied"
-        "404":
-          description: "Subscription not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/subscriptions/createSubscriptionsWithAddOns:
-    post:
-      tags:
-      - "Subscription"
-      summary: "Create multiple entitlements with addOn products"
-      description: ""
-      operationId: "createSubscriptionsWithAddOns"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            $ref: "#/definitions/BulkSubscriptionsBundle"
-      - name: "entitlementDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "billingDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "renameKeyIfExistsAndUnused"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: true
-      - name: "migrated"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "skipResponse"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "callCompletion"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "callTimeoutSec"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 3
-        format: "int64"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Subscriptions created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Bundle"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/subscriptions:
     get:
       tags:
@@ -10037,6 +9769,278 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/subscriptions/createSubscriptionWithAddOns:
+    post:
+      tags:
+      - "Subscription"
+      summary: "Create an entitlement with addOn products"
+      description: ""
+      operationId: "createSubscriptionWithAddOns"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/Subscription"
+      - name: "entitlementDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "billingDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "migrated"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "skipResponse"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "renameKeyIfExistsAndUnused"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: true
+      - name: "callCompletion"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "callTimeoutSec"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 3
+        format: "int64"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Subscriptions created successfully"
+          schema:
+            $ref: "#/definitions/Bundle"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/subscriptions/createSubscriptionsWithAddOns:
+    post:
+      tags:
+      - "Subscription"
+      summary: "Create multiple entitlements with addOn products"
+      description: ""
+      operationId: "createSubscriptionsWithAddOns"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/BulkSubscriptionsBundle"
+      - name: "entitlementDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "billingDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "renameKeyIfExistsAndUnused"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: true
+      - name: "migrated"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "skipResponse"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "callCompletion"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "callTimeoutSec"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 3
+        format: "int64"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Subscriptions created successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Bundle"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/subscriptions/{subscriptionId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Subscription"
+      summary: "Retrieve subscription audit logs with history by id"
+      description: ""
+      operationId: "getSubscriptionAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Subscription not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/subscriptions/events/{eventId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Subscription"
+      summary: "Retrieve subscription event audit logs with history by id"
+      description: ""
+      operationId: "getSubscriptionEventAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "eventId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Subscription event not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/subscriptions/{subscriptionId}/uncancel:
+    put:
+      tags:
+      - "Subscription"
+      summary: "Un-cancel an entitlement"
+      description: ""
+      operationId: "uncancelSubscriptionPlan"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid subscription id supplied"
+        "404":
+          description: "Entitlement not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/subscriptions/{subscriptionId}/undoChangePlan:
     put:
       tags:
@@ -10083,42 +10087,15 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/subscriptions/events/{eventId}/auditLogsWithHistory:
-    get:
+  /1.0/kb/subscriptions/{subscriptionId}/bcd:
+    put:
       tags:
       - "Subscription"
-      summary: "Retrieve subscription event audit logs with history by id"
+      summary: "Update the BCD associated to a subscription"
       description: ""
-      operationId: "getSubscriptionEventAuditLogsWithHistory"
-      produces:
+      operationId: "updateSubscriptionBCD"
+      consumes:
       - "application/json"
-      parameters:
-      - name: "eventId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Subscription event not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/subscriptions/{subscriptionId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Subscription"
-      summary: "Retrieve subscription audit logs with history by id"
-      description: ""
-      operationId: "getSubscriptionAuditLogsWithHistory"
       produces:
       - "application/json"
       parameters:
@@ -10128,15 +10105,38 @@ paths:
         type: "string"
         pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
         format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Subscription"
+      - name: "effectiveFromDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "forceNewBcdWithPastEffectiveDate"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Subscription not found"
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid entitlement supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -10353,35 +10353,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/tags/{tagId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Tag"
-      summary: "Retrieve tag audit logs with history by id"
-      description: ""
-      operationId: "getTagAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "tagId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Account not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/tags/search/{searchKey}:
     get:
       tags:
@@ -10425,6 +10396,203 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Tag"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/tags/{tagId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Tag"
+      summary: "Retrieve tag audit logs with history by id"
+      description: ""
+      operationId: "getTagAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "tagId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/tenants:
+    get:
+      tags:
+      - "Tenant"
+      summary: "Retrieve a tenant by its API key"
+      description: ""
+      operationId: "getTenantByApiKey"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "apiKey"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Tenant"
+        "404":
+          description: "Tenant not found"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "Tenant"
+      summary: "Create a tenant"
+      description: ""
+      operationId: "createTenant"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Tenant"
+      - name: "useGlobalDefault"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Tenant created successfully"
+          schema:
+            $ref: "#/definitions/Tenant"
+        "409":
+          description: "Tenant already exists"
+      security:
+      - basicAuth: []
+  /1.0/kb/tenants/uploadPluginPaymentStateMachineConfig/{pluginName}:
+    get:
+      tags:
+      - "Tenant"
+      summary: "Retrieve a per tenant payment state machine for a plugin"
+      description: ""
+      operationId: "getPluginPaymentStateMachineConfig"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "pluginName"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/TenantKeyValue"
+        "400":
+          description: "Invalid tenantId supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Tenant"
+      summary: "Add a per tenant payment state machine for a plugin"
+      description: ""
+      operationId: "uploadPluginPaymentStateMachineConfig"
+      consumes:
+      - "text/plain"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "pluginName"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "string"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Per tenant state machine uploaded successfully"
+          schema:
+            $ref: "#/definitions/TenantKeyValue"
+        "400":
+          description: "Invalid tenantId supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    delete:
+      tags:
+      - "Tenant"
+      summary: "Delete a per tenant payment state machine for a plugin"
+      description: ""
+      operationId: "deletePluginPaymentStateMachineConfig"
+      parameters:
+      - name: "pluginName"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "204":
+          description: "Successful operation"
+        "400":
+          description: "Invalid tenantId supplied"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -10707,137 +10875,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/tenants/uploadPerTenantConfig/{keyPrefix}/search:
-    get:
-      tags:
-      - "Tenant"
-      summary: "Retrieve a per tenant key value based on key prefix"
-      description: ""
-      operationId: "getAllPluginConfiguration"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "keyPrefix"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/TenantKeyValue"
-        "400":
-          description: "Invalid tenantId supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/tenants/uploadPluginPaymentStateMachineConfig/{pluginName}:
-    get:
-      tags:
-      - "Tenant"
-      summary: "Retrieve a per tenant payment state machine for a plugin"
-      description: ""
-      operationId: "getPluginPaymentStateMachineConfig"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "pluginName"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/TenantKeyValue"
-        "400":
-          description: "Invalid tenantId supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Tenant"
-      summary: "Add a per tenant payment state machine for a plugin"
-      description: ""
-      operationId: "uploadPluginPaymentStateMachineConfig"
-      consumes:
-      - "text/plain"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "pluginName"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "string"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Per tenant state machine uploaded successfully"
-          schema:
-            $ref: "#/definitions/TenantKeyValue"
-        "400":
-          description: "Invalid tenantId supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    delete:
-      tags:
-      - "Tenant"
-      summary: "Delete a per tenant payment state machine for a plugin"
-      description: ""
-      operationId: "deletePluginPaymentStateMachineConfig"
-      parameters:
-      - name: "pluginName"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "204":
-          description: "Successful operation"
-        "400":
-          description: "Invalid tenantId supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/tenants/userKeyValue/{keyName}:
     get:
       tags:
@@ -10941,6 +10978,34 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/tenants/uploadPerTenantConfig/{keyPrefix}/search:
+    get:
+      tags:
+      - "Tenant"
+      summary: "Retrieve a per tenant key value based on key prefix"
+      description: ""
+      operationId: "getAllPluginConfiguration"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "keyPrefix"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/TenantKeyValue"
+        "400":
+          description: "Invalid tenantId supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/tenants/{tenantId}:
     get:
       tags:
@@ -10970,71 +11035,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/tenants:
-    get:
-      tags:
-      - "Tenant"
-      summary: "Retrieve a tenant by its API key"
-      description: ""
-      operationId: "getTenantByApiKey"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "apiKey"
-        in: "query"
-        required: false
-        type: "string"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Tenant"
-        "404":
-          description: "Tenant not found"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "Tenant"
-      summary: "Create a tenant"
-      description: ""
-      operationId: "createTenant"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/Tenant"
-      - name: "useGlobalDefault"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Tenant created successfully"
-          schema:
-            $ref: "#/definitions/Tenant"
-        "409":
-          description: "Tenant already exists"
-      security:
-      - basicAuth: []
   /1.0/kb/paymentTransactions/{transactionId}/tags:
     get:
       tags:
@@ -11172,6 +11172,164 @@ paths:
           description: "Successful operation"
         "400":
           description: "Invalid transaction id supplied"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/paymentTransactions/{transactionId}:
+    get:
+      tags:
+      - "PaymentTransaction"
+      summary: "Retrieve a payment by transaction id"
+      description: ""
+      operationId: "getPaymentByTransactionId"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "transactionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - name: "withPluginInfo"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "withAttempts"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Payment"
+        "404":
+          description: "Payment not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "PaymentTransaction"
+      summary: "Mark a pending payment transaction as succeeded or failed"
+      description: ""
+      operationId: "notifyStateChanged"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "transactionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/PaymentTransaction"
+      - name: "controlPluginName"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Successfully notifiy state change"
+          schema:
+            $ref: "#/definitions/Payment"
+        "400":
+          description: "Invalid paymentId supplied"
+        "404":
+          description: "Account or Payment not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/paymentTransactions:
+    get:
+      tags:
+      - "PaymentTransaction"
+      summary: "Retrieve a payment by transaction external key"
+      description: ""
+      operationId: "getPaymentByTransactionExternalKey"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "transactionExternalKey"
+        in: "query"
+        required: true
+        type: "string"
+      - name: "withPluginInfo"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "withAttempts"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Payment"
+        "404":
+          description: "Payment not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -11383,164 +11541,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/paymentTransactions/{transactionId}:
-    get:
-      tags:
-      - "PaymentTransaction"
-      summary: "Retrieve a payment by transaction id"
-      description: ""
-      operationId: "getPaymentByTransactionId"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "transactionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - name: "withPluginInfo"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "withAttempts"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Payment"
-        "404":
-          description: "Payment not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "PaymentTransaction"
-      summary: "Mark a pending payment transaction as succeeded or failed"
-      description: ""
-      operationId: "notifyStateChanged"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "transactionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentTransaction"
-      - name: "controlPluginName"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Successfully notifiy state change"
-          schema:
-            $ref: "#/definitions/Payment"
-        "400":
-          description: "Invalid paymentId supplied"
-        "404":
-          description: "Account or Payment not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/paymentTransactions:
-    get:
-      tags:
-      - "PaymentTransaction"
-      summary: "Retrieve a payment by transaction external key"
-      description: ""
-      operationId: "getPaymentByTransactionExternalKey"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "transactionExternalKey"
-        in: "query"
-        required: true
-        type: "string"
-      - name: "withPluginInfo"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "withAttempts"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Payment"
-        "404":
-          description: "Payment not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/usages/{subscriptionId}/{unitType}:
     get:
       tags:
@@ -11729,15 +11729,15 @@ definitions:
   Entity:
     type: "object"
     properties:
-      id:
-        type: "string"
-        format: "uuid"
       updatedDate:
         type: "string"
         format: "date-time"
       createdDate:
         type: "string"
         format: "date-time"
+      id:
+        type: "string"
+        format: "uuid"
   Tag:
     type: "object"
     properties:
@@ -12007,9 +12007,26 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/AuditLog"
-  Payment:
+  AccountEmail:
+    type: "object"
+    required:
+    - "email"
+    properties:
+      accountId:
+        type: "string"
+        format: "uuid"
+      email:
+        type: "string"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
+  InvoicePayment:
     type: "object"
     properties:
+      targetInvoiceId:
+        type: "string"
+        format: "uuid"
       accountId:
         type: "string"
         format: "uuid"
@@ -12830,6 +12847,35 @@ definitions:
         type: "string"
       isUpdatable:
         type: "boolean"
+  BlockingState:
+    type: "object"
+    properties:
+      blockedId:
+        type: "string"
+        format: "uuid"
+      stateName:
+        type: "string"
+      service:
+        type: "string"
+      isBlockChange:
+        type: "boolean"
+      isBlockEntitlement:
+        type: "boolean"
+      isBlockBilling:
+        type: "boolean"
+      effectiveDate:
+        type: "string"
+        format: "date-time"
+      type:
+        type: "string"
+        enum:
+        - "SUBSCRIPTION"
+        - "SUBSCRIPTION_BUNDLE"
+        - "ACCOUNT"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
   CustomField:
     type: "object"
     required:
@@ -12872,6 +12918,321 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/AuditLog"
+  PaymentMethod:
+    type: "object"
+    properties:
+      paymentMethodId:
+        type: "string"
+        format: "uuid"
+      externalKey:
+        type: "string"
+      accountId:
+        type: "string"
+        format: "uuid"
+      isDefault:
+        type: "boolean"
+      pluginName:
+        type: "string"
+      pluginInfo:
+        $ref: "#/definitions/PaymentMethodPluginDetail"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
+  PaymentMethodPluginDetail:
+    type: "object"
+    properties:
+      externalPaymentMethodId:
+        type: "string"
+      isDefaultPaymentMethod:
+        type: "boolean"
+      properties:
+        type: "array"
+        items:
+          $ref: "#/definitions/PluginProperty"
+  BlockPrice:
+    type: "object"
+    properties:
+      unitName:
+        type: "string"
+      size:
+        type: "number"
+      price:
+        type: "number"
+      max:
+        type: "number"
+  Bundle:
+    type: "object"
+    required:
+    - "accountId"
+    properties:
+      accountId:
+        type: "string"
+        format: "uuid"
+      bundleId:
+        type: "string"
+        format: "uuid"
+      externalKey:
+        type: "string"
+      subscriptions:
+        type: "array"
+        items:
+          $ref: "#/definitions/Subscription"
+      timeline:
+        $ref: "#/definitions/BundleTimeline"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
+  BundleTimeline:
+    type: "object"
+    properties:
+      accountId:
+        type: "string"
+        format: "uuid"
+      bundleId:
+        type: "string"
+        format: "uuid"
+      externalKey:
+        type: "string"
+      events:
+        type: "array"
+        items:
+          $ref: "#/definitions/EventSubscription"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
+  EventSubscription:
+    type: "object"
+    properties:
+      eventId:
+        type: "string"
+        format: "uuid"
+      billingPeriod:
+        type: "string"
+        enum:
+        - "DAILY"
+        - "WEEKLY"
+        - "BIWEEKLY"
+        - "THIRTY_DAYS"
+        - "SIXTY_DAYS"
+        - "NINETY_DAYS"
+        - "MONTHLY"
+        - "BIMESTRIAL"
+        - "QUARTERLY"
+        - "TRIANNUAL"
+        - "BIANNUAL"
+        - "ANNUAL"
+        - "BIENNIAL"
+        - "NO_BILLING_PERIOD"
+      effectiveDate:
+        type: "string"
+        format: "date-time"
+      plan:
+        type: "string"
+      product:
+        type: "string"
+      priceList:
+        type: "string"
+      eventType:
+        type: "string"
+        enum:
+        - "START_ENTITLEMENT"
+        - "START_BILLING"
+        - "PAUSE_ENTITLEMENT"
+        - "PAUSE_BILLING"
+        - "RESUME_ENTITLEMENT"
+        - "RESUME_BILLING"
+        - "PHASE"
+        - "CHANGE"
+        - "STOP_ENTITLEMENT"
+        - "STOP_BILLING"
+        - "SERVICE_STATE_CHANGE"
+      isBlockedBilling:
+        type: "boolean"
+      isBlockedEntitlement:
+        type: "boolean"
+      serviceName:
+        type: "string"
+      serviceStateName:
+        type: "string"
+      phase:
+        type: "string"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
+  PhasePrice:
+    type: "object"
+    properties:
+      planName:
+        type: "string"
+      phaseName:
+        type: "string"
+      phaseType:
+        type: "string"
+      fixedPrice:
+        type: "number"
+      recurringPrice:
+        type: "number"
+      usagePrices:
+        type: "array"
+        items:
+          $ref: "#/definitions/UsagePrice"
+  Subscription:
+    type: "object"
+    required:
+    - "billingPeriod"
+    - "planName"
+    - "priceList"
+    - "productName"
+    properties:
+      accountId:
+        type: "string"
+        format: "uuid"
+      bundleId:
+        type: "string"
+        format: "uuid"
+      bundleExternalKey:
+        type: "string"
+      subscriptionId:
+        type: "string"
+        format: "uuid"
+      externalKey:
+        type: "string"
+      startDate:
+        type: "string"
+        format: "date-time"
+      productName:
+        type: "string"
+      productCategory:
+        type: "string"
+        enum:
+        - "BASE"
+        - "ADD_ON"
+        - "STANDALONE"
+      billingPeriod:
+        type: "string"
+        enum:
+        - "DAILY"
+        - "WEEKLY"
+        - "BIWEEKLY"
+        - "THIRTY_DAYS"
+        - "SIXTY_DAYS"
+        - "NINETY_DAYS"
+        - "MONTHLY"
+        - "BIMESTRIAL"
+        - "QUARTERLY"
+        - "TRIANNUAL"
+        - "BIANNUAL"
+        - "ANNUAL"
+        - "BIENNIAL"
+        - "NO_BILLING_PERIOD"
+      phaseType:
+        type: "string"
+        enum:
+        - "TRIAL"
+        - "DISCOUNT"
+        - "FIXEDTERM"
+        - "EVERGREEN"
+      priceList:
+        type: "string"
+      planName:
+        type: "string"
+      state:
+        type: "string"
+        enum:
+        - "PENDING"
+        - "ACTIVE"
+        - "BLOCKED"
+        - "CANCELLED"
+        - "EXPIRED"
+      sourceType:
+        type: "string"
+        enum:
+        - "NATIVE"
+        - "MIGRATED"
+        - "TRANSFERRED"
+      cancelledDate:
+        type: "string"
+        format: "date-time"
+      chargedThroughDate:
+        type: "string"
+        format: "date"
+      billingStartDate:
+        type: "string"
+        format: "date-time"
+      billingEndDate:
+        type: "string"
+        format: "date-time"
+      billCycleDayLocal:
+        type: "integer"
+        format: "int32"
+      events:
+        type: "array"
+        items:
+          $ref: "#/definitions/EventSubscription"
+      priceOverrides:
+        type: "array"
+        items:
+          $ref: "#/definitions/PhasePrice"
+      prices:
+        type: "array"
+        items:
+          $ref: "#/definitions/PhasePrice"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
+  TierPrice:
+    type: "object"
+    properties:
+      blockPrices:
+        type: "array"
+        items:
+          $ref: "#/definitions/BlockPrice"
+  UsagePrice:
+    type: "object"
+    properties:
+      usageName:
+        type: "string"
+      usageType:
+        type: "string"
+        enum:
+        - "CAPACITY"
+        - "CONSUMABLE"
+      billingMode:
+        type: "string"
+        enum:
+        - "IN_ADVANCE"
+        - "IN_ARREAR"
+      tierBlockPolicy:
+        type: "string"
+        enum:
+        - "ALL_TIERS"
+        - "TOP_TIER"
+      tierPrices:
+        type: "array"
+        items:
+          $ref: "#/definitions/TierPrice"
+  AccountTimeline:
+    type: "object"
+    properties:
+      account:
+        $ref: "#/definitions/Account"
+      bundles:
+        type: "array"
+        items:
+          $ref: "#/definitions/Bundle"
+      invoices:
+        type: "array"
+        items:
+          $ref: "#/definitions/Invoice"
+      payments:
+        type: "array"
+        items:
+          $ref: "#/definitions/InvoicePayment"
   Invoice:
     type: "object"
     properties:
@@ -13348,356 +13709,25 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/AuditLog"
-  PaymentMethod:
+  OverdueState:
     type: "object"
     properties:
-      paymentMethodId:
+      name:
         type: "string"
-        format: "uuid"
-      externalKey:
+      externalMessage:
         type: "string"
-      accountId:
-        type: "string"
-        format: "uuid"
-      isDefault:
+      isDisableEntitlementAndChangesBlocked:
         type: "boolean"
-      pluginName:
-        type: "string"
-      pluginInfo:
-        $ref: "#/definitions/PaymentMethodPluginDetail"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
-  PaymentMethodPluginDetail:
-    type: "object"
-    properties:
-      externalPaymentMethodId:
-        type: "string"
-      isDefaultPaymentMethod:
+      isBlockChanges:
         type: "boolean"
-      properties:
-        type: "array"
-        items:
-          $ref: "#/definitions/PluginProperty"
-  BlockingState:
-    type: "object"
-    properties:
-      blockedId:
-        type: "string"
-        format: "uuid"
-      stateName:
-        type: "string"
-      service:
-        type: "string"
-      isBlockChange:
+      isClearState:
         type: "boolean"
-      isBlockEntitlement:
-        type: "boolean"
-      isBlockBilling:
-        type: "boolean"
-      effectiveDate:
-        type: "string"
-        format: "date-time"
-      type:
-        type: "string"
-        enum:
-        - "SUBSCRIPTION"
-        - "SUBSCRIPTION_BUNDLE"
-        - "ACCOUNT"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
-  BlockPrice:
-    type: "object"
-    properties:
-      unitName:
-        type: "string"
-      size:
-        type: "number"
-      price:
-        type: "number"
-      max:
-        type: "number"
-  Bundle:
-    type: "object"
-    required:
-    - "accountId"
-    properties:
-      accountId:
-        type: "string"
-        format: "uuid"
-      bundleId:
-        type: "string"
-        format: "uuid"
-      externalKey:
-        type: "string"
-      subscriptions:
-        type: "array"
-        items:
-          $ref: "#/definitions/Subscription"
-      timeline:
-        $ref: "#/definitions/BundleTimeline"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
-  BundleTimeline:
-    type: "object"
-    properties:
-      accountId:
-        type: "string"
-        format: "uuid"
-      bundleId:
-        type: "string"
-        format: "uuid"
-      externalKey:
-        type: "string"
-      events:
-        type: "array"
-        items:
-          $ref: "#/definitions/EventSubscription"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
-  EventSubscription:
-    type: "object"
-    properties:
-      eventId:
-        type: "string"
-        format: "uuid"
-      billingPeriod:
-        type: "string"
-        enum:
-        - "DAILY"
-        - "WEEKLY"
-        - "BIWEEKLY"
-        - "THIRTY_DAYS"
-        - "SIXTY_DAYS"
-        - "NINETY_DAYS"
-        - "MONTHLY"
-        - "BIMESTRIAL"
-        - "QUARTERLY"
-        - "TRIANNUAL"
-        - "BIANNUAL"
-        - "ANNUAL"
-        - "BIENNIAL"
-        - "NO_BILLING_PERIOD"
-      effectiveDate:
-        type: "string"
-        format: "date-time"
-      plan:
-        type: "string"
-      product:
-        type: "string"
-      priceList:
-        type: "string"
-      eventType:
-        type: "string"
-        enum:
-        - "START_ENTITLEMENT"
-        - "START_BILLING"
-        - "PAUSE_ENTITLEMENT"
-        - "PAUSE_BILLING"
-        - "RESUME_ENTITLEMENT"
-        - "RESUME_BILLING"
-        - "PHASE"
-        - "CHANGE"
-        - "STOP_ENTITLEMENT"
-        - "STOP_BILLING"
-        - "SERVICE_STATE_CHANGE"
-      isBlockedBilling:
-        type: "boolean"
-      isBlockedEntitlement:
-        type: "boolean"
-      serviceName:
-        type: "string"
-      serviceStateName:
-        type: "string"
-      phase:
-        type: "string"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
-  PhasePrice:
-    type: "object"
-    properties:
-      planName:
-        type: "string"
-      phaseName:
-        type: "string"
-      phaseType:
-        type: "string"
-      fixedPrice:
-        type: "number"
-      recurringPrice:
-        type: "number"
-      usagePrices:
-        type: "array"
-        items:
-          $ref: "#/definitions/UsagePrice"
-  Subscription:
-    type: "object"
-    required:
-    - "billingPeriod"
-    - "planName"
-    - "priceList"
-    - "productName"
-    properties:
-      accountId:
-        type: "string"
-        format: "uuid"
-      bundleId:
-        type: "string"
-        format: "uuid"
-      bundleExternalKey:
-        type: "string"
-      subscriptionId:
-        type: "string"
-        format: "uuid"
-      externalKey:
-        type: "string"
-      startDate:
-        type: "string"
-        format: "date-time"
-      productName:
-        type: "string"
-      productCategory:
-        type: "string"
-        enum:
-        - "BASE"
-        - "ADD_ON"
-        - "STANDALONE"
-      billingPeriod:
-        type: "string"
-        enum:
-        - "DAILY"
-        - "WEEKLY"
-        - "BIWEEKLY"
-        - "THIRTY_DAYS"
-        - "SIXTY_DAYS"
-        - "NINETY_DAYS"
-        - "MONTHLY"
-        - "BIMESTRIAL"
-        - "QUARTERLY"
-        - "TRIANNUAL"
-        - "BIANNUAL"
-        - "ANNUAL"
-        - "BIENNIAL"
-        - "NO_BILLING_PERIOD"
-      phaseType:
-        type: "string"
-        enum:
-        - "TRIAL"
-        - "DISCOUNT"
-        - "FIXEDTERM"
-        - "EVERGREEN"
-      priceList:
-        type: "string"
-      planName:
-        type: "string"
-      state:
-        type: "string"
-        enum:
-        - "PENDING"
-        - "ACTIVE"
-        - "BLOCKED"
-        - "CANCELLED"
-        - "EXPIRED"
-      sourceType:
-        type: "string"
-        enum:
-        - "NATIVE"
-        - "MIGRATED"
-        - "TRANSFERRED"
-      cancelledDate:
-        type: "string"
-        format: "date-time"
-      chargedThroughDate:
-        type: "string"
-        format: "date"
-      billingStartDate:
-        type: "string"
-        format: "date-time"
-      billingEndDate:
-        type: "string"
-        format: "date-time"
-      billCycleDayLocal:
+      reevaluationIntervalDays:
         type: "integer"
         format: "int32"
-      events:
-        type: "array"
-        items:
-          $ref: "#/definitions/EventSubscription"
-      priceOverrides:
-        type: "array"
-        items:
-          $ref: "#/definitions/PhasePrice"
-      prices:
-        type: "array"
-        items:
-          $ref: "#/definitions/PhasePrice"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
-  TierPrice:
+  Payment:
     type: "object"
     properties:
-      blockPrices:
-        type: "array"
-        items:
-          $ref: "#/definitions/BlockPrice"
-  UsagePrice:
-    type: "object"
-    properties:
-      usageName:
-        type: "string"
-      usageType:
-        type: "string"
-        enum:
-        - "CAPACITY"
-        - "CONSUMABLE"
-      billingMode:
-        type: "string"
-        enum:
-        - "IN_ADVANCE"
-        - "IN_ARREAR"
-      tierBlockPolicy:
-        type: "string"
-        enum:
-        - "ALL_TIERS"
-        - "TOP_TIER"
-      tierPrices:
-        type: "array"
-        items:
-          $ref: "#/definitions/TierPrice"
-  AccountTimeline:
-    type: "object"
-    properties:
-      account:
-        $ref: "#/definitions/Account"
-      bundles:
-        type: "array"
-        items:
-          $ref: "#/definitions/Bundle"
-      invoices:
-        type: "array"
-        items:
-          $ref: "#/definitions/Invoice"
-      payments:
-        type: "array"
-        items:
-          $ref: "#/definitions/InvoicePayment"
-  InvoicePayment:
-    type: "object"
-    properties:
-      targetInvoiceId:
-        type: "string"
-        format: "uuid"
       accountId:
         type: "string"
         format: "uuid"
@@ -13901,36 +13931,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/AuditLog"
-  OverdueState:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      externalMessage:
-        type: "string"
-      isDisableEntitlementAndChangesBlocked:
-        type: "boolean"
-      isBlockChanges:
-        type: "boolean"
-      isClearState:
-        type: "boolean"
-      reevaluationIntervalDays:
-        type: "integer"
-        format: "int32"
-  AccountEmail:
-    type: "object"
-    required:
-    - "email"
-    properties:
-      accountId:
-        type: "string"
-        format: "uuid"
-      email:
-        type: "string"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
   AdminPayment:
     type: "object"
     properties:
@@ -13939,552 +13939,6 @@ definitions:
       currentPaymentStateName:
         type: "string"
       transactionStatus:
-        type: "string"
-  PlanDetail:
-    type: "object"
-    properties:
-      product:
-        type: "string"
-      plan:
-        type: "string"
-      priceList:
-        type: "string"
-      finalPhaseBillingPeriod:
-        type: "string"
-        enum:
-        - "DAILY"
-        - "WEEKLY"
-        - "BIWEEKLY"
-        - "THIRTY_DAYS"
-        - "SIXTY_DAYS"
-        - "NINETY_DAYS"
-        - "MONTHLY"
-        - "BIMESTRIAL"
-        - "QUARTERLY"
-        - "TRIANNUAL"
-        - "BIANNUAL"
-        - "ANNUAL"
-        - "BIENNIAL"
-        - "NO_BILLING_PERIOD"
-      finalPhaseRecurringPrice:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-  Price:
-    type: "object"
-    properties:
-      currency:
-        type: "string"
-        enum:
-        - "AED"
-        - "AFN"
-        - "ALL"
-        - "AMD"
-        - "ANG"
-        - "AOA"
-        - "ARS"
-        - "AUD"
-        - "AWG"
-        - "AZN"
-        - "BAM"
-        - "BBD"
-        - "BDT"
-        - "BGN"
-        - "BHD"
-        - "BIF"
-        - "BMD"
-        - "BND"
-        - "BOB"
-        - "BRL"
-        - "BSD"
-        - "BTN"
-        - "BWP"
-        - "BYR"
-        - "BZD"
-        - "CAD"
-        - "CDF"
-        - "CHF"
-        - "CLP"
-        - "CNY"
-        - "COP"
-        - "CRC"
-        - "CUC"
-        - "CUP"
-        - "CVE"
-        - "CZK"
-        - "DJF"
-        - "DKK"
-        - "DOP"
-        - "DZD"
-        - "EGP"
-        - "ERN"
-        - "ETB"
-        - "EUR"
-        - "FJD"
-        - "FKP"
-        - "GBP"
-        - "GEL"
-        - "GGP"
-        - "GHS"
-        - "GIP"
-        - "GMD"
-        - "GNF"
-        - "GTQ"
-        - "GYD"
-        - "HKD"
-        - "HNL"
-        - "HRK"
-        - "HTG"
-        - "HUF"
-        - "IDR"
-        - "ILS"
-        - "IMP"
-        - "INR"
-        - "IQD"
-        - "IRR"
-        - "ISK"
-        - "JEP"
-        - "JMD"
-        - "JOD"
-        - "JPY"
-        - "KES"
-        - "KGS"
-        - "KHR"
-        - "KMF"
-        - "KPW"
-        - "KRW"
-        - "KWD"
-        - "KYD"
-        - "KZT"
-        - "LAK"
-        - "LBP"
-        - "LKR"
-        - "LRD"
-        - "LSL"
-        - "LTL"
-        - "LVL"
-        - "LYD"
-        - "MAD"
-        - "MDL"
-        - "MGA"
-        - "MKD"
-        - "MMK"
-        - "MNT"
-        - "MOP"
-        - "MRO"
-        - "MUR"
-        - "MVR"
-        - "MWK"
-        - "MXN"
-        - "MYR"
-        - "MZN"
-        - "NAD"
-        - "NGN"
-        - "NIO"
-        - "NOK"
-        - "NPR"
-        - "NZD"
-        - "OMR"
-        - "PAB"
-        - "PEN"
-        - "PGK"
-        - "PHP"
-        - "PKR"
-        - "PLN"
-        - "PYG"
-        - "QAR"
-        - "RON"
-        - "RSD"
-        - "RUB"
-        - "RWF"
-        - "SAR"
-        - "SBD"
-        - "SCR"
-        - "SDG"
-        - "SEK"
-        - "SGD"
-        - "SHP"
-        - "SLL"
-        - "SOS"
-        - "SPL"
-        - "SRD"
-        - "STD"
-        - "SVC"
-        - "SYP"
-        - "SZL"
-        - "THB"
-        - "TJS"
-        - "TMT"
-        - "TND"
-        - "TOP"
-        - "TRY"
-        - "TTD"
-        - "TVD"
-        - "TWD"
-        - "TZS"
-        - "UAH"
-        - "UGX"
-        - "USD"
-        - "UYU"
-        - "UZS"
-        - "VEF"
-        - "VND"
-        - "VUV"
-        - "WST"
-        - "XAF"
-        - "XCD"
-        - "XDR"
-        - "XOF"
-        - "XPF"
-        - "YER"
-        - "ZAR"
-        - "ZMW"
-        - "ZWD"
-        - "BTC"
-      value:
-        type: "number"
-  Duration:
-    type: "object"
-    properties:
-      unit:
-        type: "string"
-        enum:
-        - "DAYS"
-        - "WEEKS"
-        - "MONTHS"
-        - "YEARS"
-        - "UNLIMITED"
-      number:
-        type: "integer"
-        format: "int32"
-  Limit:
-    type: "object"
-    properties:
-      unit:
-        type: "string"
-      max:
-        type: "string"
-      min:
-        type: "string"
-  Phase:
-    type: "object"
-    properties:
-      type:
-        type: "string"
-      prices:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      fixedPrices:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      duration:
-        $ref: "#/definitions/Duration"
-      usages:
-        type: "array"
-        items:
-          $ref: "#/definitions/Usage"
-  Plan:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      prettyName:
-        type: "string"
-      recurringBillingMode:
-        type: "string"
-        enum:
-        - "IN_ADVANCE"
-        - "IN_ARREAR"
-      billingPeriod:
-        type: "string"
-        enum:
-        - "DAILY"
-        - "WEEKLY"
-        - "BIWEEKLY"
-        - "THIRTY_DAYS"
-        - "SIXTY_DAYS"
-        - "NINETY_DAYS"
-        - "MONTHLY"
-        - "BIMESTRIAL"
-        - "QUARTERLY"
-        - "TRIANNUAL"
-        - "BIANNUAL"
-        - "ANNUAL"
-        - "BIENNIAL"
-        - "NO_BILLING_PERIOD"
-      phases:
-        type: "array"
-        items:
-          $ref: "#/definitions/Phase"
-  Product:
-    type: "object"
-    properties:
-      type:
-        type: "string"
-      name:
-        type: "string"
-      prettyName:
-        type: "string"
-      plans:
-        type: "array"
-        items:
-          $ref: "#/definitions/Plan"
-      included:
-        type: "array"
-        items:
-          type: "string"
-      available:
-        type: "array"
-        items:
-          type: "string"
-  Tier:
-    type: "object"
-    properties:
-      limits:
-        type: "array"
-        items:
-          $ref: "#/definitions/Limit"
-      fixedPrice:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      recurringPrice:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      blocks:
-        type: "array"
-        items:
-          $ref: "#/definitions/TieredBlock"
-  TieredBlock:
-    type: "object"
-    properties:
-      unit:
-        type: "string"
-      size:
-        type: "string"
-      max:
-        type: "string"
-      prices:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-  Usage:
-    type: "object"
-    properties:
-      billingPeriod:
-        type: "string"
-      tiers:
-        type: "array"
-        items:
-          $ref: "#/definitions/Tier"
-  PriceList:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      plans:
-        type: "array"
-        items:
-          type: "string"
-  Catalog:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      effectiveDate:
-        type: "string"
-        format: "date-time"
-      currencies:
-        type: "array"
-        items:
-          type: "string"
-          enum:
-          - "AED"
-          - "AFN"
-          - "ALL"
-          - "AMD"
-          - "ANG"
-          - "AOA"
-          - "ARS"
-          - "AUD"
-          - "AWG"
-          - "AZN"
-          - "BAM"
-          - "BBD"
-          - "BDT"
-          - "BGN"
-          - "BHD"
-          - "BIF"
-          - "BMD"
-          - "BND"
-          - "BOB"
-          - "BRL"
-          - "BSD"
-          - "BTN"
-          - "BWP"
-          - "BYR"
-          - "BZD"
-          - "CAD"
-          - "CDF"
-          - "CHF"
-          - "CLP"
-          - "CNY"
-          - "COP"
-          - "CRC"
-          - "CUC"
-          - "CUP"
-          - "CVE"
-          - "CZK"
-          - "DJF"
-          - "DKK"
-          - "DOP"
-          - "DZD"
-          - "EGP"
-          - "ERN"
-          - "ETB"
-          - "EUR"
-          - "FJD"
-          - "FKP"
-          - "GBP"
-          - "GEL"
-          - "GGP"
-          - "GHS"
-          - "GIP"
-          - "GMD"
-          - "GNF"
-          - "GTQ"
-          - "GYD"
-          - "HKD"
-          - "HNL"
-          - "HRK"
-          - "HTG"
-          - "HUF"
-          - "IDR"
-          - "ILS"
-          - "IMP"
-          - "INR"
-          - "IQD"
-          - "IRR"
-          - "ISK"
-          - "JEP"
-          - "JMD"
-          - "JOD"
-          - "JPY"
-          - "KES"
-          - "KGS"
-          - "KHR"
-          - "KMF"
-          - "KPW"
-          - "KRW"
-          - "KWD"
-          - "KYD"
-          - "KZT"
-          - "LAK"
-          - "LBP"
-          - "LKR"
-          - "LRD"
-          - "LSL"
-          - "LTL"
-          - "LVL"
-          - "LYD"
-          - "MAD"
-          - "MDL"
-          - "MGA"
-          - "MKD"
-          - "MMK"
-          - "MNT"
-          - "MOP"
-          - "MRO"
-          - "MUR"
-          - "MVR"
-          - "MWK"
-          - "MXN"
-          - "MYR"
-          - "MZN"
-          - "NAD"
-          - "NGN"
-          - "NIO"
-          - "NOK"
-          - "NPR"
-          - "NZD"
-          - "OMR"
-          - "PAB"
-          - "PEN"
-          - "PGK"
-          - "PHP"
-          - "PKR"
-          - "PLN"
-          - "PYG"
-          - "QAR"
-          - "RON"
-          - "RSD"
-          - "RUB"
-          - "RWF"
-          - "SAR"
-          - "SBD"
-          - "SCR"
-          - "SDG"
-          - "SEK"
-          - "SGD"
-          - "SHP"
-          - "SLL"
-          - "SOS"
-          - "SPL"
-          - "SRD"
-          - "STD"
-          - "SVC"
-          - "SYP"
-          - "SZL"
-          - "THB"
-          - "TJS"
-          - "TMT"
-          - "TND"
-          - "TOP"
-          - "TRY"
-          - "TTD"
-          - "TVD"
-          - "TWD"
-          - "TZS"
-          - "UAH"
-          - "UGX"
-          - "USD"
-          - "UYU"
-          - "UZS"
-          - "VEF"
-          - "VND"
-          - "VUV"
-          - "WST"
-          - "XAF"
-          - "XCD"
-          - "XDR"
-          - "XOF"
-          - "XPF"
-          - "YER"
-          - "ZAR"
-          - "ZMW"
-          - "ZWD"
-          - "BTC"
-      units:
-        type: "array"
-        items:
-          $ref: "#/definitions/Unit"
-      products:
-        type: "array"
-        items:
-          $ref: "#/definitions/Product"
-      priceLists:
-        type: "array"
-        items:
-          $ref: "#/definitions/PriceList"
-  Unit:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      prettyName:
         type: "string"
   SimplePlan:
     type: "object"
@@ -14701,6 +14155,552 @@ definitions:
         type: "array"
         items:
           type: "string"
+  PlanDetail:
+    type: "object"
+    properties:
+      product:
+        type: "string"
+      plan:
+        type: "string"
+      priceList:
+        type: "string"
+      finalPhaseBillingPeriod:
+        type: "string"
+        enum:
+        - "DAILY"
+        - "WEEKLY"
+        - "BIWEEKLY"
+        - "THIRTY_DAYS"
+        - "SIXTY_DAYS"
+        - "NINETY_DAYS"
+        - "MONTHLY"
+        - "BIMESTRIAL"
+        - "QUARTERLY"
+        - "TRIANNUAL"
+        - "BIANNUAL"
+        - "ANNUAL"
+        - "BIENNIAL"
+        - "NO_BILLING_PERIOD"
+      finalPhaseRecurringPrice:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+  Price:
+    type: "object"
+    properties:
+      currency:
+        type: "string"
+        enum:
+        - "AED"
+        - "AFN"
+        - "ALL"
+        - "AMD"
+        - "ANG"
+        - "AOA"
+        - "ARS"
+        - "AUD"
+        - "AWG"
+        - "AZN"
+        - "BAM"
+        - "BBD"
+        - "BDT"
+        - "BGN"
+        - "BHD"
+        - "BIF"
+        - "BMD"
+        - "BND"
+        - "BOB"
+        - "BRL"
+        - "BSD"
+        - "BTN"
+        - "BWP"
+        - "BYR"
+        - "BZD"
+        - "CAD"
+        - "CDF"
+        - "CHF"
+        - "CLP"
+        - "CNY"
+        - "COP"
+        - "CRC"
+        - "CUC"
+        - "CUP"
+        - "CVE"
+        - "CZK"
+        - "DJF"
+        - "DKK"
+        - "DOP"
+        - "DZD"
+        - "EGP"
+        - "ERN"
+        - "ETB"
+        - "EUR"
+        - "FJD"
+        - "FKP"
+        - "GBP"
+        - "GEL"
+        - "GGP"
+        - "GHS"
+        - "GIP"
+        - "GMD"
+        - "GNF"
+        - "GTQ"
+        - "GYD"
+        - "HKD"
+        - "HNL"
+        - "HRK"
+        - "HTG"
+        - "HUF"
+        - "IDR"
+        - "ILS"
+        - "IMP"
+        - "INR"
+        - "IQD"
+        - "IRR"
+        - "ISK"
+        - "JEP"
+        - "JMD"
+        - "JOD"
+        - "JPY"
+        - "KES"
+        - "KGS"
+        - "KHR"
+        - "KMF"
+        - "KPW"
+        - "KRW"
+        - "KWD"
+        - "KYD"
+        - "KZT"
+        - "LAK"
+        - "LBP"
+        - "LKR"
+        - "LRD"
+        - "LSL"
+        - "LTL"
+        - "LVL"
+        - "LYD"
+        - "MAD"
+        - "MDL"
+        - "MGA"
+        - "MKD"
+        - "MMK"
+        - "MNT"
+        - "MOP"
+        - "MRO"
+        - "MUR"
+        - "MVR"
+        - "MWK"
+        - "MXN"
+        - "MYR"
+        - "MZN"
+        - "NAD"
+        - "NGN"
+        - "NIO"
+        - "NOK"
+        - "NPR"
+        - "NZD"
+        - "OMR"
+        - "PAB"
+        - "PEN"
+        - "PGK"
+        - "PHP"
+        - "PKR"
+        - "PLN"
+        - "PYG"
+        - "QAR"
+        - "RON"
+        - "RSD"
+        - "RUB"
+        - "RWF"
+        - "SAR"
+        - "SBD"
+        - "SCR"
+        - "SDG"
+        - "SEK"
+        - "SGD"
+        - "SHP"
+        - "SLL"
+        - "SOS"
+        - "SPL"
+        - "SRD"
+        - "STD"
+        - "SVC"
+        - "SYP"
+        - "SZL"
+        - "THB"
+        - "TJS"
+        - "TMT"
+        - "TND"
+        - "TOP"
+        - "TRY"
+        - "TTD"
+        - "TVD"
+        - "TWD"
+        - "TZS"
+        - "UAH"
+        - "UGX"
+        - "USD"
+        - "UYU"
+        - "UZS"
+        - "VEF"
+        - "VND"
+        - "VUV"
+        - "WST"
+        - "XAF"
+        - "XCD"
+        - "XDR"
+        - "XOF"
+        - "XPF"
+        - "YER"
+        - "ZAR"
+        - "ZMW"
+        - "ZWD"
+        - "BTC"
+      value:
+        type: "number"
+  Catalog:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      effectiveDate:
+        type: "string"
+        format: "date-time"
+      currencies:
+        type: "array"
+        items:
+          type: "string"
+          enum:
+          - "AED"
+          - "AFN"
+          - "ALL"
+          - "AMD"
+          - "ANG"
+          - "AOA"
+          - "ARS"
+          - "AUD"
+          - "AWG"
+          - "AZN"
+          - "BAM"
+          - "BBD"
+          - "BDT"
+          - "BGN"
+          - "BHD"
+          - "BIF"
+          - "BMD"
+          - "BND"
+          - "BOB"
+          - "BRL"
+          - "BSD"
+          - "BTN"
+          - "BWP"
+          - "BYR"
+          - "BZD"
+          - "CAD"
+          - "CDF"
+          - "CHF"
+          - "CLP"
+          - "CNY"
+          - "COP"
+          - "CRC"
+          - "CUC"
+          - "CUP"
+          - "CVE"
+          - "CZK"
+          - "DJF"
+          - "DKK"
+          - "DOP"
+          - "DZD"
+          - "EGP"
+          - "ERN"
+          - "ETB"
+          - "EUR"
+          - "FJD"
+          - "FKP"
+          - "GBP"
+          - "GEL"
+          - "GGP"
+          - "GHS"
+          - "GIP"
+          - "GMD"
+          - "GNF"
+          - "GTQ"
+          - "GYD"
+          - "HKD"
+          - "HNL"
+          - "HRK"
+          - "HTG"
+          - "HUF"
+          - "IDR"
+          - "ILS"
+          - "IMP"
+          - "INR"
+          - "IQD"
+          - "IRR"
+          - "ISK"
+          - "JEP"
+          - "JMD"
+          - "JOD"
+          - "JPY"
+          - "KES"
+          - "KGS"
+          - "KHR"
+          - "KMF"
+          - "KPW"
+          - "KRW"
+          - "KWD"
+          - "KYD"
+          - "KZT"
+          - "LAK"
+          - "LBP"
+          - "LKR"
+          - "LRD"
+          - "LSL"
+          - "LTL"
+          - "LVL"
+          - "LYD"
+          - "MAD"
+          - "MDL"
+          - "MGA"
+          - "MKD"
+          - "MMK"
+          - "MNT"
+          - "MOP"
+          - "MRO"
+          - "MUR"
+          - "MVR"
+          - "MWK"
+          - "MXN"
+          - "MYR"
+          - "MZN"
+          - "NAD"
+          - "NGN"
+          - "NIO"
+          - "NOK"
+          - "NPR"
+          - "NZD"
+          - "OMR"
+          - "PAB"
+          - "PEN"
+          - "PGK"
+          - "PHP"
+          - "PKR"
+          - "PLN"
+          - "PYG"
+          - "QAR"
+          - "RON"
+          - "RSD"
+          - "RUB"
+          - "RWF"
+          - "SAR"
+          - "SBD"
+          - "SCR"
+          - "SDG"
+          - "SEK"
+          - "SGD"
+          - "SHP"
+          - "SLL"
+          - "SOS"
+          - "SPL"
+          - "SRD"
+          - "STD"
+          - "SVC"
+          - "SYP"
+          - "SZL"
+          - "THB"
+          - "TJS"
+          - "TMT"
+          - "TND"
+          - "TOP"
+          - "TRY"
+          - "TTD"
+          - "TVD"
+          - "TWD"
+          - "TZS"
+          - "UAH"
+          - "UGX"
+          - "USD"
+          - "UYU"
+          - "UZS"
+          - "VEF"
+          - "VND"
+          - "VUV"
+          - "WST"
+          - "XAF"
+          - "XCD"
+          - "XDR"
+          - "XOF"
+          - "XPF"
+          - "YER"
+          - "ZAR"
+          - "ZMW"
+          - "ZWD"
+          - "BTC"
+      units:
+        type: "array"
+        items:
+          $ref: "#/definitions/Unit"
+      products:
+        type: "array"
+        items:
+          $ref: "#/definitions/Product"
+      priceLists:
+        type: "array"
+        items:
+          $ref: "#/definitions/PriceList"
+  Duration:
+    type: "object"
+    properties:
+      unit:
+        type: "string"
+        enum:
+        - "DAYS"
+        - "WEEKS"
+        - "MONTHS"
+        - "YEARS"
+        - "UNLIMITED"
+      number:
+        type: "integer"
+        format: "int32"
+  Limit:
+    type: "object"
+    properties:
+      unit:
+        type: "string"
+      max:
+        type: "string"
+      min:
+        type: "string"
+  Phase:
+    type: "object"
+    properties:
+      type:
+        type: "string"
+      prices:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      fixedPrices:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      duration:
+        $ref: "#/definitions/Duration"
+      usages:
+        type: "array"
+        items:
+          $ref: "#/definitions/Usage"
+  Plan:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      prettyName:
+        type: "string"
+      recurringBillingMode:
+        type: "string"
+        enum:
+        - "IN_ADVANCE"
+        - "IN_ARREAR"
+      billingPeriod:
+        type: "string"
+        enum:
+        - "DAILY"
+        - "WEEKLY"
+        - "BIWEEKLY"
+        - "THIRTY_DAYS"
+        - "SIXTY_DAYS"
+        - "NINETY_DAYS"
+        - "MONTHLY"
+        - "BIMESTRIAL"
+        - "QUARTERLY"
+        - "TRIANNUAL"
+        - "BIANNUAL"
+        - "ANNUAL"
+        - "BIENNIAL"
+        - "NO_BILLING_PERIOD"
+      phases:
+        type: "array"
+        items:
+          $ref: "#/definitions/Phase"
+  PriceList:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      plans:
+        type: "array"
+        items:
+          type: "string"
+  Product:
+    type: "object"
+    properties:
+      type:
+        type: "string"
+      name:
+        type: "string"
+      prettyName:
+        type: "string"
+      plans:
+        type: "array"
+        items:
+          $ref: "#/definitions/Plan"
+      included:
+        type: "array"
+        items:
+          type: "string"
+      available:
+        type: "array"
+        items:
+          type: "string"
+  Tier:
+    type: "object"
+    properties:
+      limits:
+        type: "array"
+        items:
+          $ref: "#/definitions/Limit"
+      fixedPrice:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      recurringPrice:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      blocks:
+        type: "array"
+        items:
+          $ref: "#/definitions/TieredBlock"
+  TieredBlock:
+    type: "object"
+    properties:
+      unit:
+        type: "string"
+      size:
+        type: "string"
+      max:
+        type: "string"
+      prices:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+  Unit:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      prettyName:
+        type: "string"
+  Usage:
+    type: "object"
+    properties:
+      billingPeriod:
+        type: "string"
+      tiers:
+        type: "array"
+        items:
+          $ref: "#/definitions/Tier"
   InvoicePaymentTransaction:
     type: "object"
     properties:
@@ -15374,6 +15374,21 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/AuditLog"
+  UserRoles:
+    type: "object"
+    required:
+    - "password"
+    - "roles"
+    - "username"
+    properties:
+      username:
+        type: "string"
+      password:
+        type: "string"
+      roles:
+        type: "array"
+        items:
+          type: "string"
   RoleDefinition:
     type: "object"
     required:
@@ -15413,21 +15428,6 @@ definitions:
         type: "boolean"
       session:
         $ref: "#/definitions/Session"
-  UserRoles:
-    type: "object"
-    required:
-    - "password"
-    - "roles"
-    - "username"
-    properties:
-      username:
-        type: "string"
-      password:
-        type: "string"
-      roles:
-        type: "array"
-        items:
-          type: "string"
   BulkSubscriptionsBundle:
     type: "object"
     required:
@@ -15481,19 +15481,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/AuditLog"
-  TenantKeyValue:
-    type: "object"
-    properties:
-      key:
-        type: "string"
-      values:
-        type: "array"
-        items:
-          type: "string"
-      auditLogs:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLog"
   Tenant:
     type: "object"
     required:
@@ -15513,6 +15500,19 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/AuditLog"
+  TenantKeyValue:
+    type: "object"
+    properties:
+      key:
+        type: "string"
+      values:
+        type: "array"
+        items:
+          type: "string"
+      auditLogs:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLog"
   RolledUpUnit:
     type: "object"
     properties:
@@ -15528,10 +15528,10 @@ definitions:
         format: "uuid"
       startDate:
         type: "string"
-        format: "date"
+        format: "date-time"
       endDate:
         type: "string"
-        format: "date"
+        format: "date-time"
       rolledUpUnits:
         type: "array"
         items:
@@ -15565,6 +15565,6 @@ definitions:
     properties:
       recordDate:
         type: "string"
-        format: "date"
+        format: "date-time"
       amount:
         type: "number"

--- a/src/main/java/org/killbill/billing/client/RequestOptions.java
+++ b/src/main/java/org/killbill/billing/client/RequestOptions.java
@@ -19,6 +19,8 @@
 
 package org.killbill.billing.client;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,6 +28,8 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+
+import java.util.Map.Entry;
 import java.util.Objects;
 
 public class RequestOptions {
@@ -104,6 +108,13 @@ public class RequestOptions {
         return queryParams;
     }
 
+    public Map<String, Collection<String>> getQueryParamsAsMap() {
+        if (queryParams == null) {
+            return Collections.emptyMap();
+        }
+        return queryParams.asMap();
+    }
+
     public Boolean getFollowLocation() {
         return followLocation;
     }
@@ -117,6 +128,13 @@ public class RequestOptions {
 
     public Multimap<String, String> getQueryParamsForFollow() {
         return queryParamsForFollow;
+    }
+
+    public Map<String, Collection<String>> getQueryParamsForFollowAsMap() {
+        if (queryParamsForFollow == null) {
+            return Collections.emptyMap();
+        }
+        return queryParamsForFollow.asMap();
     }
 
     public RequestOptionsBuilder extend() {
@@ -277,6 +295,15 @@ public class RequestOptions {
             return this;
         }
 
+        public RequestOptionsBuilder withQueryParams(final Map<String, Collection<String>> queryParams) {
+            final Multimap<String, String> local = HashMultimap.create();
+            for (final Entry<String, Collection<String>> entry : queryParams.entrySet()) {
+                local.putAll(entry.getKey(), entry.getValue());
+            }
+            this.queryParams = local;
+            return this;
+        }
+
         public RequestOptionsBuilder withFollowLocation(final Boolean followLocation) {
             this.followLocation = followLocation;
             return this;
@@ -284,6 +311,15 @@ public class RequestOptions {
 
         public RequestOptionsBuilder withQueryParamsForFollow(final Multimap<String, String> queryParamsForFollow) {
             this.queryParamsForFollow = queryParamsForFollow;
+            return this;
+        }
+
+        public RequestOptionsBuilder withQueryParamsForFollow(final Map<String, Collection<String>> queryParamsForFollow) {
+            final Multimap<String, String> local = HashMultimap.create();
+            for (final Entry<String, Collection<String>> entry : queryParamsForFollow.entrySet()) {
+                local.putAll(entry.getKey(), entry.getValue());
+            }
+            this.queryParamsForFollow = local;
             return this;
         }
 

--- a/src/main/java/org/killbill/billing/client/model/gen/RolledUpUsage.java
+++ b/src/main/java/org/killbill/billing/client/model/gen/RolledUpUsage.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.joda.time.LocalDate;
+import org.joda.time.DateTime;
 import org.killbill.billing.client.model.gen.RolledUpUnit;
 
 /**
@@ -40,9 +40,9 @@ public class RolledUpUsage {
 
     private UUID subscriptionId = null;
 
-    private LocalDate startDate = null;
+    private DateTime startDate = null;
 
-    private LocalDate endDate = null;
+    private DateTime endDate = null;
 
     private List<RolledUpUnit> rolledUpUnits = null;
 
@@ -51,8 +51,8 @@ public class RolledUpUsage {
     }
 
     public RolledUpUsage(final UUID subscriptionId,
-                     final LocalDate startDate,
-                     final LocalDate endDate,
+                     final DateTime startDate,
+                     final DateTime endDate,
                      final List<RolledUpUnit> rolledUpUnits) {
         this.subscriptionId = subscriptionId;
         this.startDate = startDate;
@@ -71,21 +71,21 @@ public class RolledUpUsage {
         return subscriptionId;
     }
 
-    public RolledUpUsage setStartDate(final LocalDate startDate) {
+    public RolledUpUsage setStartDate(final DateTime startDate) {
         this.startDate = startDate;
         return this;
     }
 
-    public LocalDate getStartDate() {
+    public DateTime getStartDate() {
         return startDate;
     }
 
-    public RolledUpUsage setEndDate(final LocalDate endDate) {
+    public RolledUpUsage setEndDate(final DateTime endDate) {
         this.endDate = endDate;
         return this;
     }
 
-    public LocalDate getEndDate() {
+    public DateTime getEndDate() {
         return endDate;
     }
 

--- a/src/main/java/org/killbill/billing/client/model/gen/UsageRecord.java
+++ b/src/main/java/org/killbill/billing/client/model/gen/UsageRecord.java
@@ -23,7 +23,7 @@ package org.killbill.billing.client.model.gen;
 import java.util.Objects;
 import java.util.Arrays;
 import java.math.BigDecimal;
-import org.joda.time.LocalDate;
+import org.joda.time.DateTime;
 
 /**
  *           DO NOT EDIT !!!
@@ -35,7 +35,7 @@ import org.killbill.billing.client.model.KillBillObject;
 
 public class UsageRecord {
 
-    private LocalDate recordDate = null;
+    private DateTime recordDate = null;
 
     private BigDecimal amount = null;
 
@@ -43,7 +43,7 @@ public class UsageRecord {
     public UsageRecord() {
     }
 
-    public UsageRecord(final LocalDate recordDate,
+    public UsageRecord(final DateTime recordDate,
                      final BigDecimal amount) {
         this.recordDate = recordDate;
         this.amount = amount;
@@ -51,12 +51,12 @@ public class UsageRecord {
     }
 
 
-    public UsageRecord setRecordDate(final LocalDate recordDate) {
+    public UsageRecord setRecordDate(final DateTime recordDate) {
         this.recordDate = recordDate;
         return this;
     }
 
-    public LocalDate getRecordDate() {
+    public DateTime getRecordDate() {
         return recordDate;
     }
 


### PR DESCRIPTION
1. This is draft, because I'm not sure that [this commit](https://github.com/killbill/killbill-client-java/commit/cfc1cd4cb7547feb3e37196e3768515cf5c1d179) needed. But currently in `killbill-client-java`, `RolledUpUsage` and `UsageRecord` still use `LocalDate` instead of `DateTime`. This is needed, otherwise various tests in `killbill` repo failed because "type mismatch error". This "type mismatch error" will not showing up unless I start to use my local-modified `killbill-client-java` as dependency in `killbill` repository.

   In short, I only need to modify [RequestOptions](https://github.com/killbill/killbill-client-java/commit/e121aa5e708d2d44a20233f1984187079385e160), but this regenerate action is necessary because problem I explained above. If I'm doing something wrong, let me know.

2. `RequestOptions`: I'm not sure if `killbill-client-java` need to guava-free as well. But even if it's needed, then please see add thsese methods:
   - getQueryParamsAsMap()
   - getQueryParamsForFollowAsMap()
   - withQueryParams(Map<String, Collection>)
   - withQueryParamsForFollow(Map<String, Collection>)

   just a first step. Next step (if needed) will be editing `api_query.mustache` in `killbill-swagger-codegen`, and then regenerate again. 

WDYT?