### PR TITLE
Fix bug found in killbill profiles test

### DIFF
--- a/.swagger-codegen/KB_VERSION
+++ b/.swagger-codegen/KB_VERSION
@@ -1,4 +1,4 @@
 swaggerVersion=2.4.1
 kbVersion=0.23.0-SNAPSHOT
-kbApiVersion=0.54.0-eeee2bd-SNAPSHOT
-kbPluginApiVersion=0.27.0-af603fc-SNAPSHOT
+kbApiVersion=0.54.0-5b76bbc-SNAPSHOT
+kbPluginApiVersion=0.27.0-f59cc90-SNAPSHOT

--- a/.swagger-codegen/kbswagger.yaml
+++ b/.swagger-codegen/kbswagger.yaml
@@ -1081,6 +1081,35 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/accounts/{accountId}/auditLogs:
+    get:
+      tags:
+      - "Account"
+      summary: "Retrieve audit logs by account id"
+      description: ""
+      operationId: "getAccountAuditLogs"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Account not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/accounts/{accountId}/customFields:
     get:
       tags:
@@ -1255,35 +1284,6 @@ paths:
           description: "Successful operation"
         "400":
           description: "Invalid account id supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/accounts/{accountId}/auditLogs:
-    get:
-      tags:
-      - "Account"
-      summary: "Retrieve audit logs by account id"
-      description: ""
-      operationId: "getAccountAuditLogs"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Account not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -2764,6 +2764,48 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/bundles/pagination:
+    get:
+      tags:
+      - "Bundle"
+      summary: "List bundles"
+      description: ""
+      operationId: "getBundles"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int64"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 100
+        format: "int64"
+      - name: "audit"
+        in: "query"
+        required: false
+        type: "string"
+        default: "NONE"
+        enum:
+        - "FULL"
+        - "MINIMAL"
+        - "NONE"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Bundle"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/bundles/{bundleId}/block:
     post:
       tags:
@@ -2890,48 +2932,6 @@ paths:
               $ref: "#/definitions/Bundle"
         "404":
           description: "Bundle not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/bundles/pagination:
-    get:
-      tags:
-      - "Bundle"
-      summary: "List bundles"
-      description: ""
-      operationId: "getBundles"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int64"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 100
-        format: "int64"
-      - name: "audit"
-        in: "query"
-        required: false
-        type: "string"
-        default: "NONE"
-        enum:
-        - "FULL"
-        - "MINIMAL"
-        - "NONE"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Bundle"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -3228,186 +3228,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/catalog/availableAddons:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve available add-ons for a given product"
-      description: ""
-      operationId: "getAvailableAddons"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "baseProductName"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "priceListName"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "accountId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/PlanDetail"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/availableBasePlans:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve available base plans"
-      description: ""
-      operationId: "getAvailableBasePlans"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/PlanDetail"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/versions:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve a list of catalog versions"
-      description: ""
-      operationId: "getCatalogVersions"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "accountId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-              format: "date-time"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/xml:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve the full catalog as XML"
-      description: ""
-      operationId: "getCatalogXml"
-      produces:
-      - "text/xml"
-      parameters:
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date-time"
-      - name: "accountId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-    post:
-      tags:
-      - "Catalog"
-      summary: "Upload the full catalog as XML"
-      description: ""
-      operationId: "uploadCatalogXml"
-      consumes:
-      - "text/xml"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "string"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Catalog XML created successfully"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/catalog/phase:
-    get:
-      tags:
-      - "Catalog"
-      summary: "Retrieve phase for a given subscription and date"
-      description: ""
-      operationId: "getPhaseForSubscriptionAndDate"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "query"
-        required: false
-        type: "string"
-        format: "uuid"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Phase"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/catalog/plan:
     get:
       tags:
@@ -3495,6 +3315,70 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/catalog/xml:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve the full catalog as XML"
+      description: ""
+      operationId: "getCatalogXml"
+      produces:
+      - "text/xml"
+      parameters:
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date-time"
+      - name: "accountId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+    post:
+      tags:
+      - "Catalog"
+      summary: "Upload the full catalog as XML"
+      description: ""
+      operationId: "uploadCatalogXml"
+      consumes:
+      - "text/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "string"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Catalog XML created successfully"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/catalog/xml/validate:
     post:
       tags:
@@ -3527,6 +3411,122 @@ paths:
           description: "Valid XML catalog"
         "400":
           description: "Invalid XML catalog"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/availableAddons:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve available add-ons for a given product"
+      description: ""
+      operationId: "getAvailableAddons"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "baseProductName"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "priceListName"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "accountId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/PlanDetail"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/availableBasePlans:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve available base plans"
+      description: ""
+      operationId: "getAvailableBasePlans"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/PlanDetail"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/versions:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve a list of catalog versions"
+      description: ""
+      operationId: "getCatalogVersions"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "accountId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+              format: "date-time"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/catalog/phase:
+    get:
+      tags:
+      - "Catalog"
+      summary: "Retrieve phase for a given subscription and date"
+      description: ""
+      operationId: "getPhaseForSubscriptionAndDate"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "query"
+        required: false
+        type: "string"
+        format: "uuid"
+      - name: "requestedDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Phase"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -3618,21 +3618,16 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/customFields/search/{searchKey}:
+  /1.0/kb/customFields/pagination:
     get:
       tags:
       - "CustomField"
-      summary: "Search custom fields"
+      summary: "List custom fields"
       description: ""
-      operationId: "searchCustomFields"
+      operationId: "getCustomFields"
       produces:
       - "application/json"
       parameters:
-      - name: "searchKey"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: ".*"
       - name: "offset"
         in: "query"
         required: false
@@ -3665,16 +3660,21 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/customFields/pagination:
+  /1.0/kb/customFields/search/{searchKey}:
     get:
       tags:
       - "CustomField"
-      summary: "List custom fields"
+      summary: "Search custom fields"
       description: ""
-      operationId: "getCustomFields"
+      operationId: "searchCustomFields"
       produces:
       - "application/json"
       parameters:
+      - name: "searchKey"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: ".*"
       - name: "offset"
         in: "query"
         required: false
@@ -4454,61 +4454,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/invoicePayments/{paymentId}/chargebackReversals:
-    post:
-      tags:
-      - "InvoicePayment"
-      summary: "Record a chargebackReversal"
-      description: ""
-      operationId: "createChargebackReversal"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "paymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/InvoicePaymentTransaction"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Created chargeback reversal successfully"
-          schema:
-            $ref: "#/definitions/InvoicePayment"
-        "400":
-          description: "Invalid payment id supplied"
-        "404":
-          description: "Account or payment not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/invoicePayments/{paymentId}/chargebacks:
     post:
       tags:
@@ -4554,6 +4499,61 @@ paths:
       responses:
         "201":
           description: "Created chargeback successfully"
+          schema:
+            $ref: "#/definitions/InvoicePayment"
+        "400":
+          description: "Invalid payment id supplied"
+        "404":
+          description: "Account or payment not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/invoicePayments/{paymentId}/chargebackReversals:
+    post:
+      tags:
+      - "InvoicePayment"
+      summary: "Record a chargebackReversal"
+      description: ""
+      operationId: "createChargebackReversal"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "paymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/InvoicePaymentTransaction"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Created chargeback reversal successfully"
           schema:
             $ref: "#/definitions/InvoicePayment"
         "400":
@@ -4742,6 +4742,35 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
+  /1.0/kb/invoicePayments/{invoicePaymentId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "InvoicePayment"
+      summary: "Retrieve invoice payment audit logs with history by id"
+      description: ""
+      operationId: "getInvoicePaymentAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "invoicePaymentId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Invoice payment not found"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
   /1.0/kb/invoicePayments/{paymentId}/refunds:
     post:
       tags:
@@ -4803,35 +4832,6 @@ paths:
           description: "Invalid payment id supplied"
         "404":
           description: "Account or payment not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/invoicePayments/{invoicePaymentId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "InvoicePayment"
-      summary: "Retrieve invoice payment audit logs with history by id"
-      description: ""
-      operationId: "getInvoicePaymentAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "invoicePaymentId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Invoice payment not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -9434,61 +9434,32 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/subscriptions/createSubscriptionWithAddOns:
+  /1.0/kb/subscriptions/{subscriptionId}/block:
     post:
       tags:
       - "Subscription"
-      summary: "Create an entitlement with addOn products"
+      summary: "Block a subscription"
       description: ""
-      operationId: "createSubscriptionWithAddOns"
+      operationId: "addSubscriptionBlockingState"
       consumes:
       - "application/json"
-      produces:
-      - "application/json"
       parameters:
+      - name: "subscriptionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
       - in: "body"
         name: "body"
         required: true
         schema:
-          type: "array"
-          items:
-            $ref: "#/definitions/Subscription"
-      - name: "entitlementDate"
+          $ref: "#/definitions/BlockingState"
+      - name: "requestedDate"
         in: "query"
         required: false
         type: "string"
         format: "date"
-      - name: "billingDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "migrated"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "skipResponse"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "renameKeyIfExistsAndUnused"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: true
-      - name: "callCompletion"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "callTimeoutSec"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 3
-        format: "int64"
       - name: "pluginProperty"
         in: "query"
         required: false
@@ -9510,94 +9481,15 @@ paths:
         type: "string"
       responses:
         "201":
-          description: "Subscriptions created successfully"
-          schema:
-            $ref: "#/definitions/Bundle"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/subscriptions/createSubscriptionsWithAddOns:
-    post:
-      tags:
-      - "Subscription"
-      summary: "Create multiple entitlements with addOn products"
-      description: ""
-      operationId: "createSubscriptionsWithAddOns"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          type: "array"
-          items:
-            $ref: "#/definitions/BulkSubscriptionsBundle"
-      - name: "entitlementDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "billingDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "renameKeyIfExistsAndUnused"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: true
-      - name: "migrated"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "skipResponse"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "callCompletion"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "callTimeoutSec"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 3
-        format: "int64"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Subscriptions created successfully"
+          description: "Blocking state created successfully"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Bundle"
+              $ref: "#/definitions/BlockingState"
+        "400":
+          description: "Invalid subscription id supplied"
+        "404":
+          description: "Subscription not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -9799,35 +9691,6 @@ paths:
       - basicAuth: []
       - Killbill Api Key: []
       - Killbill Api Secret: []
-  /1.0/kb/subscriptions/{subscriptionId}/auditLogsWithHistory:
-    get:
-      tags:
-      - "Subscription"
-      summary: "Retrieve subscription audit logs with history by id"
-      description: ""
-      operationId: "getSubscriptionAuditLogsWithHistory"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/AuditLog"
-        "404":
-          description: "Subscription not found"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
   /1.0/kb/subscriptions:
     get:
       tags:
@@ -9938,6 +9801,203 @@ paths:
           description: "Subscription created successfully"
           schema:
             $ref: "#/definitions/Subscription"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/subscriptions/createSubscriptionWithAddOns:
+    post:
+      tags:
+      - "Subscription"
+      summary: "Create an entitlement with addOn products"
+      description: ""
+      operationId: "createSubscriptionWithAddOns"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/Subscription"
+      - name: "entitlementDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "billingDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "migrated"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "skipResponse"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "renameKeyIfExistsAndUnused"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: true
+      - name: "callCompletion"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "callTimeoutSec"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 3
+        format: "int64"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Subscriptions created successfully"
+          schema:
+            $ref: "#/definitions/Bundle"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/subscriptions/createSubscriptionsWithAddOns:
+    post:
+      tags:
+      - "Subscription"
+      summary: "Create multiple entitlements with addOn products"
+      description: ""
+      operationId: "createSubscriptionsWithAddOns"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/BulkSubscriptionsBundle"
+      - name: "entitlementDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "billingDate"
+        in: "query"
+        required: false
+        type: "string"
+        format: "date"
+      - name: "renameKeyIfExistsAndUnused"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: true
+      - name: "migrated"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "skipResponse"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "callCompletion"
+        in: "query"
+        required: false
+        type: "boolean"
+        default: false
+      - name: "callTimeoutSec"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 3
+        format: "int64"
+      - name: "pluginProperty"
+        in: "query"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      - name: "X-Killbill-CreatedBy"
+        in: "header"
+        required: true
+        type: "string"
+      - name: "X-Killbill-Reason"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "X-Killbill-Comment"
+        in: "header"
+        required: false
+        type: "string"
+      responses:
+        "201":
+          description: "Subscriptions created successfully"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Bundle"
+      security:
+      - basicAuth: []
+      - Killbill Api Key: []
+      - Killbill Api Secret: []
+  /1.0/kb/subscriptions/{subscriptionId}/auditLogsWithHistory:
+    get:
+      tags:
+      - "Subscription"
+      summary: "Retrieve subscription audit logs with history by id"
+      description: ""
+      operationId: "getSubscriptionAuditLogsWithHistory"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "subscriptionId"
+        in: "path"
+        required: true
+        type: "string"
+        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
+        format: "uuid"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/AuditLog"
+        "404":
+          description: "Subscription not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -10113,66 +10173,6 @@ paths:
           description: "Successful operation"
         "400":
           description: "Invalid entitlement supplied"
-      security:
-      - basicAuth: []
-      - Killbill Api Key: []
-      - Killbill Api Secret: []
-  /1.0/kb/subscriptions/{subscriptionId}/block:
-    post:
-      tags:
-      - "Subscription"
-      summary: "Block a subscription"
-      description: ""
-      operationId: "addSubscriptionBlockingState"
-      consumes:
-      - "application/json"
-      parameters:
-      - name: "subscriptionId"
-        in: "path"
-        required: true
-        type: "string"
-        pattern: "\\w+-\\w+-\\w+-\\w+-\\w+"
-        format: "uuid"
-      - in: "body"
-        name: "body"
-        required: true
-        schema:
-          $ref: "#/definitions/BlockingState"
-      - name: "requestedDate"
-        in: "query"
-        required: false
-        type: "string"
-        format: "date"
-      - name: "pluginProperty"
-        in: "query"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
-      - name: "X-Killbill-CreatedBy"
-        in: "header"
-        required: true
-        type: "string"
-      - name: "X-Killbill-Reason"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "X-Killbill-Comment"
-        in: "header"
-        required: false
-        type: "string"
-      responses:
-        "201":
-          description: "Blocking state created successfully"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/BlockingState"
-        "400":
-          description: "Invalid subscription id supplied"
-        "404":
-          description: "Subscription not found"
       security:
       - basicAuth: []
       - Killbill Api Key: []
@@ -11765,15 +11765,15 @@ definitions:
   Entity:
     type: "object"
     properties:
-      createdDate:
-        type: "string"
-        format: "date-time"
-      updatedDate:
-        type: "string"
-        format: "date-time"
       id:
         type: "string"
         format: "uuid"
+      updatedDate:
+        type: "string"
+        format: "date-time"
+      createdDate:
+        type: "string"
+        format: "date-time"
   Tag:
     type: "object"
     properties:
@@ -14191,16 +14191,61 @@ definitions:
         type: "array"
         items:
           type: "string"
-  PlanDetail:
+  Duration:
     type: "object"
     properties:
-      product:
+      unit:
         type: "string"
-      plan:
+        enum:
+        - "DAYS"
+        - "WEEKS"
+        - "MONTHS"
+        - "YEARS"
+        - "UNLIMITED"
+      number:
+        type: "integer"
+        format: "int32"
+  Limit:
+    type: "object"
+    properties:
+      unit:
         type: "string"
-      priceList:
+      max:
         type: "string"
-      finalPhaseBillingPeriod:
+      min:
+        type: "string"
+  Phase:
+    type: "object"
+    properties:
+      type:
+        type: "string"
+      prices:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      fixedPrices:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      duration:
+        $ref: "#/definitions/Duration"
+      usages:
+        type: "array"
+        items:
+          $ref: "#/definitions/Usage"
+  Plan:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      prettyName:
+        type: "string"
+      recurringBillingMode:
+        type: "string"
+        enum:
+        - "IN_ADVANCE"
+        - "IN_ARREAR"
+      billingPeriod:
         type: "string"
         enum:
         - "DAILY"
@@ -14217,10 +14262,10 @@ definitions:
         - "ANNUAL"
         - "BIENNIAL"
         - "NO_BILLING_PERIOD"
-      finalPhaseRecurringPrice:
+      phases:
         type: "array"
         items:
-          $ref: "#/definitions/Price"
+          $ref: "#/definitions/Phase"
   Price:
     type: "object"
     properties:
@@ -14394,6 +14439,107 @@ definitions:
         - "BTC"
       value:
         type: "number"
+  Tier:
+    type: "object"
+    properties:
+      limits:
+        type: "array"
+        items:
+          $ref: "#/definitions/Limit"
+      fixedPrice:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      recurringPrice:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+      blocks:
+        type: "array"
+        items:
+          $ref: "#/definitions/TieredBlock"
+  TieredBlock:
+    type: "object"
+    properties:
+      unit:
+        type: "string"
+      size:
+        type: "string"
+      max:
+        type: "string"
+      prices:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
+  Usage:
+    type: "object"
+    properties:
+      billingPeriod:
+        type: "string"
+      tiers:
+        type: "array"
+        items:
+          $ref: "#/definitions/Tier"
+  PriceList:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      plans:
+        type: "array"
+        items:
+          type: "string"
+  Product:
+    type: "object"
+    properties:
+      type:
+        type: "string"
+      name:
+        type: "string"
+      prettyName:
+        type: "string"
+      plans:
+        type: "array"
+        items:
+          $ref: "#/definitions/Plan"
+      included:
+        type: "array"
+        items:
+          type: "string"
+      available:
+        type: "array"
+        items:
+          type: "string"
+  PlanDetail:
+    type: "object"
+    properties:
+      product:
+        type: "string"
+      plan:
+        type: "string"
+      priceList:
+        type: "string"
+      finalPhaseBillingPeriod:
+        type: "string"
+        enum:
+        - "DAILY"
+        - "WEEKLY"
+        - "BIWEEKLY"
+        - "THIRTY_DAYS"
+        - "SIXTY_DAYS"
+        - "NINETY_DAYS"
+        - "MONTHLY"
+        - "BIMESTRIAL"
+        - "QUARTERLY"
+        - "TRIANNUAL"
+        - "BIANNUAL"
+        - "ANNUAL"
+        - "BIENNIAL"
+        - "NO_BILLING_PERIOD"
+      finalPhaseRecurringPrice:
+        type: "array"
+        items:
+          $ref: "#/definitions/Price"
   Catalog:
     type: "object"
     properties:
@@ -14584,143 +14730,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/PriceList"
-  Duration:
-    type: "object"
-    properties:
-      unit:
-        type: "string"
-        enum:
-        - "DAYS"
-        - "WEEKS"
-        - "MONTHS"
-        - "YEARS"
-        - "UNLIMITED"
-      number:
-        type: "integer"
-        format: "int32"
-  Limit:
-    type: "object"
-    properties:
-      unit:
-        type: "string"
-      max:
-        type: "string"
-      min:
-        type: "string"
-  Phase:
-    type: "object"
-    properties:
-      type:
-        type: "string"
-      prices:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      fixedPrices:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      duration:
-        $ref: "#/definitions/Duration"
-      usages:
-        type: "array"
-        items:
-          $ref: "#/definitions/Usage"
-  Plan:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      prettyName:
-        type: "string"
-      recurringBillingMode:
-        type: "string"
-        enum:
-        - "IN_ADVANCE"
-        - "IN_ARREAR"
-      billingPeriod:
-        type: "string"
-        enum:
-        - "DAILY"
-        - "WEEKLY"
-        - "BIWEEKLY"
-        - "THIRTY_DAYS"
-        - "SIXTY_DAYS"
-        - "NINETY_DAYS"
-        - "MONTHLY"
-        - "BIMESTRIAL"
-        - "QUARTERLY"
-        - "TRIANNUAL"
-        - "BIANNUAL"
-        - "ANNUAL"
-        - "BIENNIAL"
-        - "NO_BILLING_PERIOD"
-      phases:
-        type: "array"
-        items:
-          $ref: "#/definitions/Phase"
-  PriceList:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      plans:
-        type: "array"
-        items:
-          type: "string"
-  Product:
-    type: "object"
-    properties:
-      type:
-        type: "string"
-      name:
-        type: "string"
-      prettyName:
-        type: "string"
-      plans:
-        type: "array"
-        items:
-          $ref: "#/definitions/Plan"
-      included:
-        type: "array"
-        items:
-          type: "string"
-      available:
-        type: "array"
-        items:
-          type: "string"
-  Tier:
-    type: "object"
-    properties:
-      limits:
-        type: "array"
-        items:
-          $ref: "#/definitions/Limit"
-      fixedPrice:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      recurringPrice:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
-      blocks:
-        type: "array"
-        items:
-          $ref: "#/definitions/TieredBlock"
-  TieredBlock:
-    type: "object"
-    properties:
-      unit:
-        type: "string"
-      size:
-        type: "string"
-      max:
-        type: "string"
-      prices:
-        type: "array"
-        items:
-          $ref: "#/definitions/Price"
   Unit:
     type: "object"
     properties:
@@ -14728,15 +14737,6 @@ definitions:
         type: "string"
       prettyName:
         type: "string"
-  Usage:
-    type: "object"
-    properties:
-      billingPeriod:
-        type: "string"
-      tiers:
-        type: "array"
-        items:
-          $ref: "#/definitions/Tier"
   InvoicePaymentTransaction:
     type: "object"
     properties:

--- a/src/main/java/org/killbill/billing/client/RequestOptions.java
+++ b/src/main/java/org/killbill/billing/client/RequestOptions.java
@@ -19,11 +19,13 @@
 
 package org.killbill.billing.client;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Map.Entry;
 import java.util.Objects;
 
 public class RequestOptions {
@@ -103,7 +105,7 @@ public class RequestOptions {
     }
 
     public Map<String, Collection<String>> getQueryParams() {
-        return Map.copyOf(queryParams);
+        return new HashMap<>(queryParams);
     }
 
     public Boolean getFollowLocation() {
@@ -118,7 +120,7 @@ public class RequestOptions {
     }
 
     public Map<String, Collection<String>> getQueryParamsForFollow() {
-        return Map.copyOf(queryParamsForFollow);
+        return new HashMap<>(queryParamsForFollow);
     }
 
     public RequestOptionsBuilder extend() {
@@ -275,7 +277,7 @@ public class RequestOptions {
         }
 
         public RequestOptionsBuilder withQueryParams(final Map<String, ? extends Collection<String>> queryParams) {
-            this.queryParams = queryParams;
+            this.queryParams = toMutableMapValues(queryParams);
             return this;
         }
 
@@ -285,13 +287,29 @@ public class RequestOptions {
         }
 
         public RequestOptionsBuilder withQueryParamsForFollow(final Map<String, ? extends Collection<String>> queryParamsForFollow) {
-            this.queryParamsForFollow = queryParamsForFollow;
+            this.queryParamsForFollow = toMutableMapValues(queryParamsForFollow);
             return this;
         }
 
         public RequestOptions build() {
             return new RequestOptions(requestId, user, password, createdBy, reason, comment, tenantApiKey, tenantApiSecret,
                                       headers, queryParams, followLocation, queryParamsForFollow);
+        }
+
+        /**
+         * Make sure that map collection values are mutable. Used to rebuild method parameter in
+         * {@link #withQueryParams(Map)} and {@link #withQueryParamsForFollow(Map)} .
+         *
+         * See {@code TestRequestOptions} for why we may need this.
+         */
+        Map<String, ? extends Collection<String>> toMutableMapValues(final Map<String, ? extends Collection<String>> map) {
+            final Map<String, Collection<String>> result = new HashMap<>();
+
+            for (final Entry<String, ? extends Collection<String>> entry : map.entrySet()) {
+                result.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+            }
+
+            return result;
         }
     }
 }

--- a/src/main/java/org/killbill/billing/client/api/gen/AccountApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/AccountApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.Account;
@@ -66,6 +62,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -85,40 +84,25 @@ public class AccountApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public BlockingStates addAccountBlockingState(final UUID accountId, final BlockingState body, final LocalDate requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling addAccountBlockingState");
-        checkNotNull(body, "Missing the required parameter 'body' when calling addAccountBlockingState");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling addAccountBlockingState");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addAccountBlockingState");
 
         final String uri = "/1.0/kb/accounts/{accountId}/block"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -126,8 +110,8 @@ public class AccountApi {
     }
 
     public AccountEmails addEmail(final UUID accountId, final AccountEmail body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling addEmail");
-        checkNotNull(body, "Missing the required parameter 'body' when calling addEmail");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling addEmail");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addEmail");
 
         final String uri = "/1.0/kb/accounts/{accountId}/emails"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -149,27 +133,27 @@ public class AccountApi {
 
 
     public void closeAccount(final UUID accountId, final Boolean cancelAllSubscriptions, final Boolean writeOffUnpaidInvoices, final Boolean itemAdjustUnpaidInvoices, final Boolean removeFutureNotifications, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling closeAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling closeAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (cancelAllSubscriptions != null) {
-            addToMapValues(queryParams, "cancelAllSubscriptions", List.of(String.valueOf(cancelAllSubscriptions)));
+            queryParams.put("cancelAllSubscriptions", String.valueOf(cancelAllSubscriptions));
         }
         if (writeOffUnpaidInvoices != null) {
-            addToMapValues(queryParams, "writeOffUnpaidInvoices", List.of(String.valueOf(writeOffUnpaidInvoices)));
+            queryParams.put("writeOffUnpaidInvoices", String.valueOf(writeOffUnpaidInvoices));
         }
         if (itemAdjustUnpaidInvoices != null) {
-            addToMapValues(queryParams, "itemAdjustUnpaidInvoices", List.of(String.valueOf(itemAdjustUnpaidInvoices)));
+            queryParams.put("itemAdjustUnpaidInvoices", String.valueOf(itemAdjustUnpaidInvoices));
         }
         if (removeFutureNotifications != null) {
-            addToMapValues(queryParams, "removeFutureNotifications", List.of(String.valueOf(removeFutureNotifications)));
+            queryParams.put("removeFutureNotifications", String.valueOf(removeFutureNotifications));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -177,7 +161,7 @@ public class AccountApi {
     }
 
     public Account createAccount(final Account body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createAccount");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createAccount");
 
         final String uri = "/1.0/kb/accounts";
 
@@ -193,8 +177,8 @@ public class AccountApi {
     }
 
     public CustomFields createAccountCustomFields(final UUID accountId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createAccountCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createAccountCustomFields");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createAccountCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createAccountCustomFields");
 
         final String uri = "/1.0/kb/accounts/{accountId}/customFields"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -211,8 +195,8 @@ public class AccountApi {
     }
 
     public Tags createAccountTags(final UUID accountId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createAccountTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createAccountTags");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createAccountTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createAccountTags");
 
         final String uri = "/1.0/kb/accounts/{accountId}/tags"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -233,30 +217,30 @@ public class AccountApi {
     }
 
     public PaymentMethod createPaymentMethod(final UUID accountId, final PaymentMethod body, final Boolean isDefault, final Boolean payAllUnpaidInvoices, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createPaymentMethod");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentMethod");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createPaymentMethod");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentMethod");
 
         final String uri = "/1.0/kb/accounts/{accountId}/paymentMethods"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (isDefault != null) {
-            addToMapValues(queryParams, "isDefault", List.of(String.valueOf(isDefault)));
+            queryParams.put("isDefault", String.valueOf(isDefault));
         }
         if (payAllUnpaidInvoices != null) {
-            addToMapValues(queryParams, "payAllUnpaidInvoices", List.of(String.valueOf(payAllUnpaidInvoices)));
+            queryParams.put("payAllUnpaidInvoices", String.valueOf(payAllUnpaidInvoices));
         }
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -266,18 +250,18 @@ public class AccountApi {
 
 
     public void deleteAccountCustomFields(final UUID accountId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling deleteAccountCustomFields");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling deleteAccountCustomFields");
 
         final String uri = "/1.0/kb/accounts/{accountId}/customFields"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -287,18 +271,18 @@ public class AccountApi {
 
 
     public void deleteAccountTags(final UUID accountId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling deleteAccountTags");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling deleteAccountTags");
 
         final String uri = "/1.0/kb/accounts/{accountId}/tags"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -311,24 +295,24 @@ public class AccountApi {
     }
 
     public Account getAccount(final UUID accountId, final Boolean accountWithBalance, final Boolean accountWithBalanceAndCBA, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountWithBalance != null) {
-            addToMapValues(queryParams, "accountWithBalance", List.of(String.valueOf(accountWithBalance)));
+            queryParams.put("accountWithBalance", String.valueOf(accountWithBalance));
         }
         if (accountWithBalanceAndCBA != null) {
-            addToMapValues(queryParams, "accountWithBalanceAndCBA", List.of(String.valueOf(accountWithBalanceAndCBA)));
+            queryParams.put("accountWithBalanceAndCBA", String.valueOf(accountWithBalanceAndCBA));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -336,7 +320,7 @@ public class AccountApi {
     }
 
     public AuditLogs getAccountAuditLogs(final UUID accountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountAuditLogs");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountAuditLogs");
 
         final String uri = "/1.0/kb/accounts/{accountId}/auditLogs"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -350,7 +334,7 @@ public class AccountApi {
     }
 
     public AuditLogs getAccountAuditLogsWithHistory(final UUID accountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountAuditLogsWithHistory");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/accounts/{accountId}/auditLogsWithHistory"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -368,24 +352,24 @@ public class AccountApi {
     }
 
     public Bundles getAccountBundles(final UUID accountId, final String externalKey, final String bundlesFilter, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountBundles");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountBundles");
 
         final String uri = "/1.0/kb/accounts/{accountId}/bundles"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalKey != null) {
-            addToMapValues(queryParams, "externalKey", List.of(String.valueOf(externalKey)));
+            queryParams.put("externalKey", String.valueOf(externalKey));
         }
         if (bundlesFilter != null) {
-            addToMapValues(queryParams, "bundlesFilter", List.of(String.valueOf(bundlesFilter)));
+            queryParams.put("bundlesFilter", String.valueOf(bundlesFilter));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -397,26 +381,26 @@ public class AccountApi {
     }
 
     public Account getAccountByKey(final String externalKey, final Boolean accountWithBalance, final Boolean accountWithBalanceAndCBA, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getAccountByKey");
+        Preconditions.checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getAccountByKey");
 
         final String uri = "/1.0/kb/accounts";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalKey != null) {
-            addToMapValues(queryParams, "externalKey", List.of(String.valueOf(externalKey)));
+            queryParams.put("externalKey", String.valueOf(externalKey));
         }
         if (accountWithBalance != null) {
-            addToMapValues(queryParams, "accountWithBalance", List.of(String.valueOf(accountWithBalance)));
+            queryParams.put("accountWithBalance", String.valueOf(accountWithBalance));
         }
         if (accountWithBalanceAndCBA != null) {
-            addToMapValues(queryParams, "accountWithBalanceAndCBA", List.of(String.valueOf(accountWithBalanceAndCBA)));
+            queryParams.put("accountWithBalanceAndCBA", String.valueOf(accountWithBalanceAndCBA));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -428,18 +412,18 @@ public class AccountApi {
     }
 
     public CustomFields getAccountCustomFields(final UUID accountId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountCustomFields");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountCustomFields");
 
         final String uri = "/1.0/kb/accounts/{accountId}/customFields"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -447,8 +431,8 @@ public class AccountApi {
     }
 
     public AuditLogs getAccountEmailAuditLogsWithHistory(final UUID accountId, final UUID accountEmailId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountEmailAuditLogsWithHistory");
-        checkNotNull(accountEmailId, "Missing the required parameter 'accountEmailId' when calling getAccountEmailAuditLogsWithHistory");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountEmailAuditLogsWithHistory");
+        Preconditions.checkNotNull(accountEmailId, "Missing the required parameter 'accountEmailId' when calling getAccountEmailAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/accounts/{accountId}/emails/{accountEmailId}/auditLogsWithHistory"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString())
@@ -467,21 +451,21 @@ public class AccountApi {
     }
 
     public Tags getAccountTags(final UUID accountId, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountTags");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountTags");
 
         final String uri = "/1.0/kb/accounts/{accountId}/tags"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -493,21 +477,21 @@ public class AccountApi {
     }
 
     public AccountTimeline getAccountTimeline(final UUID accountId, final Boolean parallel, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountTimeline");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAccountTimeline");
 
         final String uri = "/1.0/kb/accounts/{accountId}/timeline"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (parallel != null) {
-            addToMapValues(queryParams, "parallel", List.of(String.valueOf(parallel)));
+            queryParams.put("parallel", String.valueOf(parallel));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -522,25 +506,25 @@ public class AccountApi {
 
         final String uri = "/1.0/kb/accounts/pagination";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (accountWithBalance != null) {
-            addToMapValues(queryParams, "accountWithBalance", List.of(String.valueOf(accountWithBalance)));
+            queryParams.put("accountWithBalance", String.valueOf(accountWithBalance));
         }
         if (accountWithBalanceAndCBA != null) {
-            addToMapValues(queryParams, "accountWithBalanceAndCBA", List.of(String.valueOf(accountWithBalanceAndCBA)));
+            queryParams.put("accountWithBalanceAndCBA", String.valueOf(accountWithBalanceAndCBA));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -552,21 +536,21 @@ public class AccountApi {
     }
 
     public CustomFields getAllCustomFields(final UUID accountId, final ObjectType objectType, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAllCustomFields");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAllCustomFields");
 
         final String uri = "/1.0/kb/accounts/{accountId}/allCustomFields"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (objectType != null) {
-            addToMapValues(queryParams, "objectType", List.of(String.valueOf(objectType)));
+            queryParams.put("objectType", String.valueOf(objectType));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -578,24 +562,24 @@ public class AccountApi {
     }
 
     public Tags getAllTags(final UUID accountId, final ObjectType objectType, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAllTags");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getAllTags");
 
         final String uri = "/1.0/kb/accounts/{accountId}/allTags"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (objectType != null) {
-            addToMapValues(queryParams, "objectType", List.of(String.valueOf(objectType)));
+            queryParams.put("objectType", String.valueOf(objectType));
         }
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -603,7 +587,7 @@ public class AccountApi {
     }
 
     public AuditLogs getBlockingStateAuditLogsWithHistory(final UUID blockingId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(blockingId, "Missing the required parameter 'blockingId' when calling getBlockingStateAuditLogsWithHistory");
+        Preconditions.checkNotNull(blockingId, "Missing the required parameter 'blockingId' when calling getBlockingStateAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/accounts/block/{blockingId}/auditLogsWithHistory"
           .replaceAll("\\{" + "blockingId" + "\\}", blockingId.toString());
@@ -621,24 +605,24 @@ public class AccountApi {
     }
 
     public BlockingStates getBlockingStates(final UUID accountId, final List<BlockingStateType> blockingStateTypes, final List<String> blockingStateSvcs, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getBlockingStates");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getBlockingStates");
 
         final String uri = "/1.0/kb/accounts/{accountId}/block"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (blockingStateTypes != null) {
-            addToMapValues(queryParams, "blockingStateTypes", Converter.convertEnumListToStringList(blockingStateTypes));
+            queryParams.putAll("blockingStateTypes", Converter.convertEnumListToStringList(blockingStateTypes));
         }
         if (blockingStateSvcs != null) {
-            addToMapValues(queryParams, "blockingStateSvcs", blockingStateSvcs);
+            queryParams.putAll("blockingStateSvcs", blockingStateSvcs);
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -650,24 +634,24 @@ public class AccountApi {
     }
 
     public Accounts getChildrenAccounts(final UUID accountId, final Boolean accountWithBalance, final Boolean accountWithBalanceAndCBA, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getChildrenAccounts");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getChildrenAccounts");
 
         final String uri = "/1.0/kb/accounts/{accountId}/children"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountWithBalance != null) {
-            addToMapValues(queryParams, "accountWithBalance", List.of(String.valueOf(accountWithBalance)));
+            queryParams.put("accountWithBalance", String.valueOf(accountWithBalance));
         }
         if (accountWithBalanceAndCBA != null) {
-            addToMapValues(queryParams, "accountWithBalanceAndCBA", List.of(String.valueOf(accountWithBalanceAndCBA)));
+            queryParams.put("accountWithBalanceAndCBA", String.valueOf(accountWithBalanceAndCBA));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -675,7 +659,7 @@ public class AccountApi {
     }
 
     public AccountEmails getEmails(final UUID accountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getEmails");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getEmails");
 
         final String uri = "/1.0/kb/accounts/{accountId}/emails"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -693,27 +677,27 @@ public class AccountApi {
     }
 
     public InvoicePayments getInvoicePayments(final UUID accountId, final Boolean withPluginInfo, final Boolean withAttempts, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoicePayments");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoicePayments");
 
         final String uri = "/1.0/kb/accounts/{accountId}/invoicePayments"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -725,36 +709,36 @@ public class AccountApi {
     }
 
     public Invoices getInvoicesForAccount(final UUID accountId, final LocalDate startDate, final LocalDate endDate, final Boolean withMigrationInvoices, final Boolean unpaidInvoicesOnly, final Boolean includeVoidedInvoices, final String invoicesFilter, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoicesForAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoicesForAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}/invoices"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (startDate != null) {
-            addToMapValues(queryParams, "startDate", List.of(String.valueOf(startDate)));
+            queryParams.put("startDate", String.valueOf(startDate));
         }
         if (endDate != null) {
-            addToMapValues(queryParams, "endDate", List.of(String.valueOf(endDate)));
+            queryParams.put("endDate", String.valueOf(endDate));
         }
         if (withMigrationInvoices != null) {
-            addToMapValues(queryParams, "withMigrationInvoices", List.of(String.valueOf(withMigrationInvoices)));
+            queryParams.put("withMigrationInvoices", String.valueOf(withMigrationInvoices));
         }
         if (unpaidInvoicesOnly != null) {
-            addToMapValues(queryParams, "unpaidInvoicesOnly", List.of(String.valueOf(unpaidInvoicesOnly)));
+            queryParams.put("unpaidInvoicesOnly", String.valueOf(unpaidInvoicesOnly));
         }
         if (includeVoidedInvoices != null) {
-            addToMapValues(queryParams, "includeVoidedInvoices", List.of(String.valueOf(includeVoidedInvoices)));
+            queryParams.put("includeVoidedInvoices", String.valueOf(includeVoidedInvoices));
         }
         if (invoicesFilter != null) {
-            addToMapValues(queryParams, "invoicesFilter", List.of(String.valueOf(invoicesFilter)));
+            queryParams.put("invoicesFilter", String.valueOf(invoicesFilter));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -762,7 +746,7 @@ public class AccountApi {
     }
 
     public OverdueState getOverdueAccount(final UUID accountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getOverdueAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getOverdueAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}/overdue"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -780,27 +764,27 @@ public class AccountApi {
     }
 
     public PaymentMethods getPaymentMethodsForAccount(final UUID accountId, final Boolean withPluginInfo, final Boolean includedDeleted, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getPaymentMethodsForAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getPaymentMethodsForAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}/paymentMethods"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -812,27 +796,27 @@ public class AccountApi {
     }
 
     public Payments getPaymentsForAccount(final UUID accountId, final Boolean withAttempts, final Boolean withPluginInfo, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getPaymentsForAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getPaymentsForAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}/payments"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -840,8 +824,8 @@ public class AccountApi {
     }
 
     public void modifyAccountCustomFields(final UUID accountId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling modifyAccountCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyAccountCustomFields");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling modifyAccountCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyAccountCustomFields");
 
         final String uri = "/1.0/kb/accounts/{accountId}/customFields"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -860,32 +844,32 @@ public class AccountApi {
     }
 
     public Invoices payAllInvoices(final UUID accountId, final UUID paymentMethodId, final Boolean externalPayment, final BigDecimal paymentAmount, final LocalDate targetDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling payAllInvoices");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling payAllInvoices");
 
         final String uri = "/1.0/kb/accounts/{accountId}/invoicePayments"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (paymentMethodId != null) {
-            addToMapValues(queryParams, "paymentMethodId", List.of(String.valueOf(paymentMethodId)));
+            queryParams.put("paymentMethodId", String.valueOf(paymentMethodId));
         }
         if (externalPayment != null) {
-            addToMapValues(queryParams, "externalPayment", List.of(String.valueOf(externalPayment)));
+            queryParams.put("externalPayment", String.valueOf(externalPayment));
         }
         if (paymentAmount != null) {
-            addToMapValues(queryParams, "paymentAmount", List.of(String.valueOf(paymentAmount)));
+            queryParams.put("paymentAmount", String.valueOf(paymentAmount));
         }
         if (targetDate != null) {
-            addToMapValues(queryParams, "targetDate", List.of(String.valueOf(targetDate)));
+            queryParams.put("targetDate", String.valueOf(targetDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -894,27 +878,27 @@ public class AccountApi {
     }
 
     public Payment processPayment(final UUID accountId, final PaymentTransaction body, final UUID paymentMethodId, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling processPayment");
-        checkNotNull(body, "Missing the required parameter 'body' when calling processPayment");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling processPayment");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling processPayment");
 
         final String uri = "/1.0/kb/accounts/{accountId}/payments"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (paymentMethodId != null) {
-            addToMapValues(queryParams, "paymentMethodId", List.of(String.valueOf(paymentMethodId)));
+            queryParams.put("paymentMethodId", String.valueOf(paymentMethodId));
         }
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -923,29 +907,29 @@ public class AccountApi {
     }
 
     public Payment processPaymentByExternalKey(final PaymentTransaction body, final String externalKey, final UUID paymentMethodId, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling processPaymentByExternalKey");
-        checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling processPaymentByExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling processPaymentByExternalKey");
+        Preconditions.checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling processPaymentByExternalKey");
 
         final String uri = "/1.0/kb/accounts/payments";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalKey != null) {
-            addToMapValues(queryParams, "externalKey", List.of(String.valueOf(externalKey)));
+            queryParams.put("externalKey", String.valueOf(externalKey));
         }
         if (paymentMethodId != null) {
-            addToMapValues(queryParams, "paymentMethodId", List.of(String.valueOf(paymentMethodId)));
+            queryParams.put("paymentMethodId", String.valueOf(paymentMethodId));
         }
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -954,7 +938,7 @@ public class AccountApi {
     }
 
     public void rebalanceExistingCBAOnAccount(final UUID accountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling rebalanceExistingCBAOnAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling rebalanceExistingCBAOnAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}/cbaRebalancing"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -969,21 +953,21 @@ public class AccountApi {
     }
 
     public void refreshPaymentMethods(final UUID accountId, final String pluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling refreshPaymentMethods");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling refreshPaymentMethods");
 
         final String uri = "/1.0/kb/accounts/{accountId}/paymentMethods/refresh"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (pluginName != null) {
-            addToMapValues(queryParams, "pluginName", List.of(String.valueOf(pluginName)));
+            queryParams.put("pluginName", String.valueOf(pluginName));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -992,8 +976,8 @@ public class AccountApi {
 
 
     public void removeEmail(final UUID accountId, final String email, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling removeEmail");
-        checkNotNull(email, "Missing the required parameter 'email' when calling removeEmail");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling removeEmail");
+        Preconditions.checkNotNull(email, "Missing the required parameter 'email' when calling removeEmail");
 
         final String uri = "/1.0/kb/accounts/{accountId}/emails/{email}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString())
@@ -1012,30 +996,30 @@ public class AccountApi {
     }
 
     public Accounts searchAccounts(final String searchKey, final Long offset, final Long limit, final Boolean accountWithBalance, final Boolean accountWithBalanceAndCBA, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchAccounts");
+        Preconditions.checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchAccounts");
 
         final String uri = "/1.0/kb/accounts/search/{searchKey}"
           .replaceAll("\\{" + "searchKey" + "\\}", searchKey.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (accountWithBalance != null) {
-            addToMapValues(queryParams, "accountWithBalance", List.of(String.valueOf(accountWithBalance)));
+            queryParams.put("accountWithBalance", String.valueOf(accountWithBalance));
         }
         if (accountWithBalanceAndCBA != null) {
-            addToMapValues(queryParams, "accountWithBalanceAndCBA", List.of(String.valueOf(accountWithBalanceAndCBA)));
+            queryParams.put("accountWithBalanceAndCBA", String.valueOf(accountWithBalanceAndCBA));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -1047,23 +1031,23 @@ public class AccountApi {
     }
 
     public void setDefaultPaymentMethod(final UUID accountId, final UUID paymentMethodId, final Boolean payAllUnpaidInvoices, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling setDefaultPaymentMethod");
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling setDefaultPaymentMethod");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling setDefaultPaymentMethod");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling setDefaultPaymentMethod");
 
         final String uri = "/1.0/kb/accounts/{accountId}/paymentMethods/{paymentMethodId}/setDefault"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString())
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (payAllUnpaidInvoices != null) {
-            addToMapValues(queryParams, "payAllUnpaidInvoices", List.of(String.valueOf(payAllUnpaidInvoices)));
+            queryParams.put("payAllUnpaidInvoices", String.valueOf(payAllUnpaidInvoices));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -1072,7 +1056,7 @@ public class AccountApi {
     }
 
     public void transferChildCreditToParent(final UUID childAccountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(childAccountId, "Missing the required parameter 'childAccountId' when calling transferChildCreditToParent");
+        Preconditions.checkNotNull(childAccountId, "Missing the required parameter 'childAccountId' when calling transferChildCreditToParent");
 
         final String uri = "/1.0/kb/accounts/{childAccountId}/transferCredit"
           .replaceAll("\\{" + "childAccountId" + "\\}", childAccountId.toString());
@@ -1091,19 +1075,19 @@ public class AccountApi {
     }
 
     public void updateAccount(final UUID accountId, final Account body, final Boolean treatNullAsReset, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling updateAccount");
-        checkNotNull(body, "Missing the required parameter 'body' when calling updateAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling updateAccount");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling updateAccount");
 
         final String uri = "/1.0/kb/accounts/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (treatNullAsReset != null) {
-            addToMapValues(queryParams, "treatNullAsReset", List.of(String.valueOf(treatNullAsReset)));
+            queryParams.put("treatNullAsReset", String.valueOf(treatNullAsReset));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();

--- a/src/main/java/org/killbill/billing/client/api/gen/AdminApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/AdminApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AdminPayment;
@@ -39,6 +35,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -58,21 +57,6 @@ public class AdminApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public int getQueueEntries(final UUID accountId, final String queueName, final String serviceName, final String minDate, final String maxDate, final OutputStream outputStream, final RequestOptions inputOptions) throws KillBillClientException {
         return getQueueEntries(accountId, queueName, serviceName, Boolean.valueOf(true), minDate, maxDate, Boolean.valueOf(true), Boolean.valueOf(true), Boolean.valueOf(true), outputStream, inputOptions);
     }
@@ -81,37 +65,37 @@ public class AdminApi {
 
         final String uri = "/1.0/kb/admin/queues";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
         if (queueName != null) {
-            addToMapValues(queryParams, "queueName", List.of(String.valueOf(queueName)));
+            queryParams.put("queueName", String.valueOf(queueName));
         }
         if (serviceName != null) {
-            addToMapValues(queryParams, "serviceName", List.of(String.valueOf(serviceName)));
+            queryParams.put("serviceName", String.valueOf(serviceName));
         }
         if (withHistory != null) {
-            addToMapValues(queryParams, "withHistory", List.of(String.valueOf(withHistory)));
+            queryParams.put("withHistory", String.valueOf(withHistory));
         }
         if (minDate != null) {
-            addToMapValues(queryParams, "minDate", List.of(String.valueOf(minDate)));
+            queryParams.put("minDate", String.valueOf(minDate));
         }
         if (maxDate != null) {
-            addToMapValues(queryParams, "maxDate", List.of(String.valueOf(maxDate)));
+            queryParams.put("maxDate", String.valueOf(maxDate));
         }
         if (withInProcessing != null) {
-            addToMapValues(queryParams, "withInProcessing", List.of(String.valueOf(withInProcessing)));
+            queryParams.put("withInProcessing", String.valueOf(withInProcessing));
         }
         if (withBusEvents != null) {
-            addToMapValues(queryParams, "withBusEvents", List.of(String.valueOf(withBusEvents)));
+            queryParams.put("withBusEvents", String.valueOf(withBusEvents));
         }
         if (withNotifications != null) {
-            addToMapValues(queryParams, "withNotifications", List.of(String.valueOf(withNotifications)));
+            queryParams.put("withNotifications", String.valueOf(withNotifications));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/octet-stream");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -124,13 +108,13 @@ public class AdminApi {
 
         final String uri = "/1.0/kb/admin/cache";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (cacheName != null) {
-            addToMapValues(queryParams, "cacheName", List.of(String.valueOf(cacheName)));
+            queryParams.put("cacheName", String.valueOf(cacheName));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -139,7 +123,7 @@ public class AdminApi {
 
 
     public void invalidatesCacheByAccount(final UUID accountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling invalidatesCacheByAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling invalidatesCacheByAccount");
 
         final String uri = "/1.0/kb/admin/cache/accounts/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
@@ -198,21 +182,21 @@ public class AdminApi {
 
         final String uri = "/1.0/kb/admin/invoices";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -221,9 +205,9 @@ public class AdminApi {
     }
 
     public void updatePaymentTransactionState(final UUID paymentId, final UUID paymentTransactionId, final AdminPayment body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling updatePaymentTransactionState");
-        checkNotNull(paymentTransactionId, "Missing the required parameter 'paymentTransactionId' when calling updatePaymentTransactionState");
-        checkNotNull(body, "Missing the required parameter 'body' when calling updatePaymentTransactionState");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling updatePaymentTransactionState");
+        Preconditions.checkNotNull(paymentTransactionId, "Missing the required parameter 'paymentTransactionId' when calling updatePaymentTransactionState");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling updatePaymentTransactionState");
 
         final String uri = "/1.0/kb/admin/payments/{paymentId}/transactions/{paymentTransactionId}"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString())

--- a/src/main/java/org/killbill/billing/client/api/gen/BundleApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/BundleApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -50,6 +46,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -69,40 +68,25 @@ public class BundleApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public BlockingStates addBundleBlockingState(final UUID bundleId, final BlockingState body, final LocalDate requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling addBundleBlockingState");
-        checkNotNull(body, "Missing the required parameter 'body' when calling addBundleBlockingState");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling addBundleBlockingState");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addBundleBlockingState");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/block"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -110,24 +94,24 @@ public class BundleApi {
     }
 
     public BlockingStates addBundleBlockingState(final UUID bundleId, final BlockingState body, final DateTime requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling addBundleBlockingState");
-        checkNotNull(body, "Missing the required parameter 'body' when calling addBundleBlockingState");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling addBundleBlockingState");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addBundleBlockingState");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/block"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -135,8 +119,8 @@ public class BundleApi {
     }
 
     public CustomFields createBundleCustomFields(final UUID bundleId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling createBundleCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createBundleCustomFields");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling createBundleCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createBundleCustomFields");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/customFields"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
@@ -153,8 +137,8 @@ public class BundleApi {
     }
 
     public Tags createBundleTags(final UUID bundleId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling createBundleTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createBundleTags");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling createBundleTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createBundleTags");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/tags"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
@@ -172,18 +156,18 @@ public class BundleApi {
 
 
     public void deleteBundleCustomFields(final UUID bundleId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling deleteBundleCustomFields");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling deleteBundleCustomFields");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/customFields"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -193,18 +177,18 @@ public class BundleApi {
 
 
     public void deleteBundleTags(final UUID bundleId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling deleteBundleTags");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling deleteBundleTags");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/tags"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -217,18 +201,18 @@ public class BundleApi {
     }
 
     public Bundle getBundle(final UUID bundleId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundle");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundle");
 
         final String uri = "/1.0/kb/bundles/{bundleId}"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -236,7 +220,7 @@ public class BundleApi {
     }
 
     public AuditLogs getBundleAuditLogsWithHistory(final UUID bundleId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundleAuditLogsWithHistory");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundleAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/auditLogsWithHistory"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
@@ -254,23 +238,23 @@ public class BundleApi {
     }
 
     public Bundles getBundleByKey(final String externalKey, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getBundleByKey");
+        Preconditions.checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getBundleByKey");
 
         final String uri = "/1.0/kb/bundles";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalKey != null) {
-            addToMapValues(queryParams, "externalKey", List.of(String.valueOf(externalKey)));
+            queryParams.put("externalKey", String.valueOf(externalKey));
         }
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -282,18 +266,18 @@ public class BundleApi {
     }
 
     public CustomFields getBundleCustomFields(final UUID bundleId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundleCustomFields");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundleCustomFields");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/customFields"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -305,21 +289,21 @@ public class BundleApi {
     }
 
     public Tags getBundleTags(final UUID bundleId, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundleTags");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling getBundleTags");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/tags"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -334,19 +318,19 @@ public class BundleApi {
 
         final String uri = "/1.0/kb/bundles/pagination";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -354,8 +338,8 @@ public class BundleApi {
     }
 
     public void modifyBundleCustomFields(final UUID bundleId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling modifyBundleCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyBundleCustomFields");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling modifyBundleCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyBundleCustomFields");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/customFields"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
@@ -370,21 +354,21 @@ public class BundleApi {
     }
 
     public void pauseBundle(final UUID bundleId, final LocalDate requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling pauseBundle");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling pauseBundle");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/pause"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -393,8 +377,8 @@ public class BundleApi {
     }
 
     public void renameExternalKey(final UUID bundleId, final Bundle body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling renameExternalKey");
-        checkNotNull(body, "Missing the required parameter 'body' when calling renameExternalKey");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling renameExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling renameExternalKey");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/renameKey"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
@@ -408,21 +392,21 @@ public class BundleApi {
     }
 
     public void resumeBundle(final UUID bundleId, final LocalDate requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling resumeBundle");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling resumeBundle");
 
         final String uri = "/1.0/kb/bundles/{bundleId}/resume"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -435,24 +419,24 @@ public class BundleApi {
     }
 
     public Bundles searchBundles(final String searchKey, final Long offset, final Long limit, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchBundles");
+        Preconditions.checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchBundles");
 
         final String uri = "/1.0/kb/bundles/search/{searchKey}"
           .replaceAll("\\{" + "searchKey" + "\\}", searchKey.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -464,27 +448,27 @@ public class BundleApi {
     }
 
     public Bundle transferBundle(final UUID bundleId, final Bundle body, final LocalDate requestedDate, final BillingActionPolicy billingPolicy, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling transferBundle");
-        checkNotNull(body, "Missing the required parameter 'body' when calling transferBundle");
+        Preconditions.checkNotNull(bundleId, "Missing the required parameter 'bundleId' when calling transferBundle");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling transferBundle");
 
         final String uri = "/1.0/kb/bundles/{bundleId}"
           .replaceAll("\\{" + "bundleId" + "\\}", bundleId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (billingPolicy != null) {
-            addToMapValues(queryParams, "billingPolicy", List.of(String.valueOf(billingPolicy)));
+            queryParams.put("billingPolicy", String.valueOf(billingPolicy));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();

--- a/src/main/java/org/killbill/billing/client/api/gen/CatalogApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/CatalogApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.Catalog;
@@ -47,6 +43,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -66,23 +65,8 @@ public class CatalogApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public String addSimplePlan(final SimplePlan body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling addSimplePlan");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addSimplePlan");
 
         final String uri = "/1.0/kb/catalog/simplePlan";
 
@@ -113,19 +97,19 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/availableAddons";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (baseProductName != null) {
-            addToMapValues(queryParams, "baseProductName", List.of(String.valueOf(baseProductName)));
+            queryParams.put("baseProductName", String.valueOf(baseProductName));
         }
         if (priceListName != null) {
-            addToMapValues(queryParams, "priceListName", List.of(String.valueOf(priceListName)));
+            queryParams.put("priceListName", String.valueOf(priceListName));
         }
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -136,13 +120,13 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/availableBasePlans";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -153,16 +137,16 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -173,13 +157,13 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/versions";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -190,16 +174,16 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/xml";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "text/xml");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -210,16 +194,16 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/phase";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (subscriptionId != null) {
-            addToMapValues(queryParams, "subscriptionId", List.of(String.valueOf(subscriptionId)));
+            queryParams.put("subscriptionId", String.valueOf(subscriptionId));
         }
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -230,16 +214,16 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/plan";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (subscriptionId != null) {
-            addToMapValues(queryParams, "subscriptionId", List.of(String.valueOf(subscriptionId)));
+            queryParams.put("subscriptionId", String.valueOf(subscriptionId));
         }
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -250,16 +234,16 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/priceList";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (subscriptionId != null) {
-            addToMapValues(queryParams, "subscriptionId", List.of(String.valueOf(subscriptionId)));
+            queryParams.put("subscriptionId", String.valueOf(subscriptionId));
         }
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -270,16 +254,16 @@ public class CatalogApi {
 
         final String uri = "/1.0/kb/catalog/product";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (subscriptionId != null) {
-            addToMapValues(queryParams, "subscriptionId", List.of(String.valueOf(subscriptionId)));
+            queryParams.put("subscriptionId", String.valueOf(subscriptionId));
         }
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -287,7 +271,7 @@ public class CatalogApi {
     }
 
     public String uploadCatalogXml(final String body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadCatalogXml");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadCatalogXml");
 
         final String uri = "/1.0/kb/catalog/xml";
 
@@ -302,7 +286,7 @@ public class CatalogApi {
     }
 
     public void validateCatalogXml(final String body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling validateCatalogXml");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling validateCatalogXml");
 
         final String uri = "/1.0/kb/catalog/xml/validate";
 

--- a/src/main/java/org/killbill/billing/client/api/gen/CreditApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/CreditApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.InvoiceItem;
@@ -38,6 +34,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -57,42 +56,27 @@ public class CreditApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public InvoiceItems createCredits(final InvoiceItems body, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
         return createCredits(body, Boolean.valueOf(false), pluginProperty, inputOptions);
     }
 
     public InvoiceItems createCredits(final InvoiceItems body, final Boolean autoCommit, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createCredits");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createCredits");
 
         final String uri = "/1.0/kb/credits";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (autoCommit != null) {
-            addToMapValues(queryParams, "autoCommit", List.of(String.valueOf(autoCommit)));
+            queryParams.put("autoCommit", String.valueOf(autoCommit));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -101,7 +85,7 @@ public class CreditApi {
     }
 
     public InvoiceItem getCredit(final UUID creditId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(creditId, "Missing the required parameter 'creditId' when calling getCredit");
+        Preconditions.checkNotNull(creditId, "Missing the required parameter 'creditId' when calling getCredit");
 
         final String uri = "/1.0/kb/credits/{creditId}"
           .replaceAll("\\{" + "creditId" + "\\}", creditId.toString());

--- a/src/main/java/org/killbill/billing/client/api/gen/CustomFieldApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/CustomFieldApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -40,6 +36,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -59,23 +58,8 @@ public class CustomFieldApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public AuditLogs getCustomFieldAuditLogsWithHistory(final UUID customFieldId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(customFieldId, "Missing the required parameter 'customFieldId' when calling getCustomFieldAuditLogsWithHistory");
+        Preconditions.checkNotNull(customFieldId, "Missing the required parameter 'customFieldId' when calling getCustomFieldAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/customFields/{customFieldId}/auditLogsWithHistory"
           .replaceAll("\\{" + "customFieldId" + "\\}", customFieldId.toString());
@@ -96,19 +80,19 @@ public class CustomFieldApi {
 
         final String uri = "/1.0/kb/customFields/pagination";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -120,24 +104,24 @@ public class CustomFieldApi {
     }
 
     public CustomFields searchCustomFields(final String searchKey, final Long offset, final Long limit, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchCustomFields");
+        Preconditions.checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchCustomFields");
 
         final String uri = "/1.0/kb/customFields/search/{searchKey}"
           .replaceAll("\\{" + "searchKey" + "\\}", searchKey.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -152,28 +136,28 @@ public class CustomFieldApi {
 
         final String uri = "/1.0/kb/customFields/search";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (objectType != null) {
-            addToMapValues(queryParams, "objectType", List.of(String.valueOf(objectType)));
+            queryParams.put("objectType", String.valueOf(objectType));
         }
         if (fieldName != null) {
-            addToMapValues(queryParams, "fieldName", List.of(String.valueOf(fieldName)));
+            queryParams.put("fieldName", String.valueOf(fieldName));
         }
         if (fieldValue != null) {
-            addToMapValues(queryParams, "fieldValue", List.of(String.valueOf(fieldValue)));
+            queryParams.put("fieldValue", String.valueOf(fieldValue));
         }
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 

--- a/src/main/java/org/killbill/billing/client/api/gen/ExportApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/ExportApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import java.util.UUID;
@@ -37,6 +33,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -56,23 +55,8 @@ public class ExportApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public int exportDataForAccount(final UUID accountId, final OutputStream outputStream, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling exportDataForAccount");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling exportDataForAccount");
 
         final String uri = "/1.0/kb/export/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());

--- a/src/main/java/org/killbill/billing/client/api/gen/InvoiceApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/InvoiceApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -51,6 +47,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -70,40 +69,25 @@ public class InvoiceApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public Invoice adjustInvoiceItem(final UUID invoiceId, final InvoiceItem body, final LocalDate requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling adjustInvoiceItem");
-        checkNotNull(body, "Missing the required parameter 'body' when calling adjustInvoiceItem");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling adjustInvoiceItem");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling adjustInvoiceItem");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -112,7 +96,7 @@ public class InvoiceApi {
     }
 
     public void commitInvoice(final UUID invoiceId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling commitInvoice");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling commitInvoice");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/commitInvoice"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
@@ -131,27 +115,27 @@ public class InvoiceApi {
     }
 
     public InvoiceItems createExternalCharges(final UUID accountId, final InvoiceItems body, final LocalDate requestedDate, final Boolean autoCommit, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createExternalCharges");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createExternalCharges");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createExternalCharges");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createExternalCharges");
 
         final String uri = "/1.0/kb/invoices/charges/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (autoCommit != null) {
-            addToMapValues(queryParams, "autoCommit", List.of(String.valueOf(autoCommit)));
+            queryParams.put("autoCommit", String.valueOf(autoCommit));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -160,25 +144,25 @@ public class InvoiceApi {
     }
 
     public Invoice createFutureInvoice(final UUID accountId, final LocalDate targetDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createFutureInvoice");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createFutureInvoice");
 
         final String uri = "/1.0/kb/invoices";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
         if (targetDate != null) {
-            addToMapValues(queryParams, "targetDate", List.of(String.valueOf(targetDate)));
+            queryParams.put("targetDate", String.valueOf(targetDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -187,25 +171,25 @@ public class InvoiceApi {
     }
 
     public Invoices createFutureInvoiceGroup(final UUID accountId, final LocalDate targetDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createFutureInvoiceGroup");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createFutureInvoiceGroup");
 
         final String uri = "/1.0/kb/invoices/group";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
         if (targetDate != null) {
-            addToMapValues(queryParams, "targetDate", List.of(String.valueOf(targetDate)));
+            queryParams.put("targetDate", String.valueOf(targetDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -218,27 +202,27 @@ public class InvoiceApi {
     }
 
     public InvoicePayment createInstantPayment(final UUID invoiceId, final InvoicePayment body, final Boolean externalPayment, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling createInstantPayment");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createInstantPayment");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling createInstantPayment");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createInstantPayment");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/payments"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalPayment != null) {
-            addToMapValues(queryParams, "externalPayment", List.of(String.valueOf(externalPayment)));
+            queryParams.put("externalPayment", String.valueOf(externalPayment));
         }
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -247,8 +231,8 @@ public class InvoiceApi {
     }
 
     public CustomFields createInvoiceCustomFields(final UUID invoiceId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling createInvoiceCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceCustomFields");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling createInvoiceCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceCustomFields");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/customFields"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
@@ -265,8 +249,8 @@ public class InvoiceApi {
     }
 
     public Tags createInvoiceTags(final UUID invoiceId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling createInvoiceTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceTags");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling createInvoiceTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceTags");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/tags"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
@@ -283,21 +267,21 @@ public class InvoiceApi {
     }
 
     public Invoice createMigrationInvoice(final UUID accountId, final InvoiceItems body, final LocalDate targetDate, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createMigrationInvoice");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createMigrationInvoice");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createMigrationInvoice");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createMigrationInvoice");
 
         final String uri = "/1.0/kb/invoices/migration/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (targetDate != null) {
-            addToMapValues(queryParams, "targetDate", List.of(String.valueOf(targetDate)));
+            queryParams.put("targetDate", String.valueOf(targetDate));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -310,27 +294,27 @@ public class InvoiceApi {
     }
 
     public InvoiceItems createTaxItems(final UUID accountId, final InvoiceItems body, final Boolean autoCommit, final LocalDate requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createTaxItems");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createTaxItems");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling createTaxItems");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createTaxItems");
 
         final String uri = "/1.0/kb/invoices/taxes/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (autoCommit != null) {
-            addToMapValues(queryParams, "autoCommit", List.of(String.valueOf(autoCommit)));
+            queryParams.put("autoCommit", String.valueOf(autoCommit));
         }
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -340,21 +324,21 @@ public class InvoiceApi {
 
 
     public void deleteCBA(final UUID invoiceId, final UUID invoiceItemId, final UUID accountId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling deleteCBA");
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling deleteCBA");
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling deleteCBA");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling deleteCBA");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling deleteCBA");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling deleteCBA");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/{invoiceItemId}/cba"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString())
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -364,18 +348,18 @@ public class InvoiceApi {
 
 
     public void deleteInvoiceCustomFields(final UUID invoiceId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling deleteInvoiceCustomFields");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling deleteInvoiceCustomFields");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/customFields"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -385,18 +369,18 @@ public class InvoiceApi {
 
 
     public void deleteInvoiceTags(final UUID invoiceId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling deleteInvoiceTags");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling deleteInvoiceTags");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/tags"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -405,26 +389,26 @@ public class InvoiceApi {
     }
 
     public Invoice generateDryRunInvoice(final InvoiceDryRun body, final UUID accountId, final LocalDate targetDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling generateDryRunInvoice");
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling generateDryRunInvoice");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling generateDryRunInvoice");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling generateDryRunInvoice");
 
         final String uri = "/1.0/kb/invoices/dryRun";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
         if (targetDate != null) {
-            addToMapValues(queryParams, "targetDate", List.of(String.valueOf(targetDate)));
+            queryParams.put("targetDate", String.valueOf(targetDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -433,7 +417,7 @@ public class InvoiceApi {
     }
 
     public String getCatalogTranslation(final String locale, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(locale, "Missing the required parameter 'locale' when calling getCatalogTranslation");
+        Preconditions.checkNotNull(locale, "Missing the required parameter 'locale' when calling getCatalogTranslation");
 
         final String uri = "/1.0/kb/invoices/catalogTranslation/{locale}"
           .replaceAll("\\{" + "locale" + "\\}", locale.toString());
@@ -451,21 +435,21 @@ public class InvoiceApi {
     }
 
     public Invoice getInvoice(final UUID invoiceId, final Boolean withChildrenItems, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoice");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoice");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withChildrenItems != null) {
-            addToMapValues(queryParams, "withChildrenItems", List.of(String.valueOf(withChildrenItems)));
+            queryParams.put("withChildrenItems", String.valueOf(withChildrenItems));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -473,7 +457,7 @@ public class InvoiceApi {
     }
 
     public String getInvoiceAsHTML(final UUID invoiceId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceAsHTML");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceAsHTML");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/html"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
@@ -487,7 +471,7 @@ public class InvoiceApi {
     }
 
     public AuditLogs getInvoiceAuditLogsWithHistory(final UUID invoiceId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceAuditLogsWithHistory");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/auditLogsWithHistory"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
@@ -505,21 +489,21 @@ public class InvoiceApi {
     }
 
     public Invoice getInvoiceByItemId(final UUID itemId, final Boolean withChildrenItems, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(itemId, "Missing the required parameter 'itemId' when calling getInvoiceByItemId");
+        Preconditions.checkNotNull(itemId, "Missing the required parameter 'itemId' when calling getInvoiceByItemId");
 
         final String uri = "/1.0/kb/invoices/byItemId/{itemId}"
           .replaceAll("\\{" + "itemId" + "\\}", itemId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withChildrenItems != null) {
-            addToMapValues(queryParams, "withChildrenItems", List.of(String.valueOf(withChildrenItems)));
+            queryParams.put("withChildrenItems", String.valueOf(withChildrenItems));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -531,21 +515,21 @@ public class InvoiceApi {
     }
 
     public Invoice getInvoiceByNumber(final Integer invoiceNumber, final Boolean withChildrenItems, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceNumber, "Missing the required parameter 'invoiceNumber' when calling getInvoiceByNumber");
+        Preconditions.checkNotNull(invoiceNumber, "Missing the required parameter 'invoiceNumber' when calling getInvoiceByNumber");
 
         final String uri = "/1.0/kb/invoices/byNumber/{invoiceNumber}"
           .replaceAll("\\{" + "invoiceNumber" + "\\}", invoiceNumber.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withChildrenItems != null) {
-            addToMapValues(queryParams, "withChildrenItems", List.of(String.valueOf(withChildrenItems)));
+            queryParams.put("withChildrenItems", String.valueOf(withChildrenItems));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -557,18 +541,18 @@ public class InvoiceApi {
     }
 
     public CustomFields getInvoiceCustomFields(final UUID invoiceId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceCustomFields");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceCustomFields");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/customFields"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -576,7 +560,7 @@ public class InvoiceApi {
     }
 
     public String getInvoiceMPTemplate(final String locale, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(locale, "Missing the required parameter 'locale' when calling getInvoiceMPTemplate");
+        Preconditions.checkNotNull(locale, "Missing the required parameter 'locale' when calling getInvoiceMPTemplate");
 
         final String uri = "/1.0/kb/invoices/manualPayTemplate/{locale}"
           .replaceAll("\\{" + "locale" + "\\}", locale.toString());
@@ -594,21 +578,21 @@ public class InvoiceApi {
     }
 
     public Tags getInvoiceTags(final UUID invoiceId, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceTags");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getInvoiceTags");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/tags"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -628,7 +612,7 @@ public class InvoiceApi {
     }
 
     public String getInvoiceTranslation(final String locale, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(locale, "Missing the required parameter 'locale' when calling getInvoiceTranslation");
+        Preconditions.checkNotNull(locale, "Missing the required parameter 'locale' when calling getInvoiceTranslation");
 
         final String uri = "/1.0/kb/invoices/translation/{locale}"
           .replaceAll("\\{" + "locale" + "\\}", locale.toString());
@@ -649,19 +633,19 @@ public class InvoiceApi {
 
         final String uri = "/1.0/kb/invoices/pagination";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -673,25 +657,25 @@ public class InvoiceApi {
     }
 
     public Invoices getInvoicesGroup(final UUID groupId, final UUID accountId, final Boolean withChildrenItems, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(groupId, "Missing the required parameter 'groupId' when calling getInvoicesGroup");
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoicesGroup");
+        Preconditions.checkNotNull(groupId, "Missing the required parameter 'groupId' when calling getInvoicesGroup");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoicesGroup");
 
         final String uri = "/1.0/kb/invoices/{groupId}/group"
           .replaceAll("\\{" + "groupId" + "\\}", groupId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
         if (withChildrenItems != null) {
-            addToMapValues(queryParams, "withChildrenItems", List.of(String.valueOf(withChildrenItems)));
+            queryParams.put("withChildrenItems", String.valueOf(withChildrenItems));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -703,24 +687,24 @@ public class InvoiceApi {
     }
 
     public InvoicePayments getPaymentsForInvoice(final UUID invoiceId, final Boolean withPluginInfo, final Boolean withAttempts, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getPaymentsForInvoice");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling getPaymentsForInvoice");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/payments"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -728,8 +712,8 @@ public class InvoiceApi {
     }
 
     public void modifyInvoiceCustomFields(final UUID invoiceId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling modifyInvoiceCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyInvoiceCustomFields");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling modifyInvoiceCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyInvoiceCustomFields");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/customFields"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());
@@ -748,24 +732,24 @@ public class InvoiceApi {
     }
 
     public Invoices searchInvoices(final String searchKey, final Long offset, final Long limit, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchInvoices");
+        Preconditions.checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchInvoices");
 
         final String uri = "/1.0/kb/invoices/search/{searchKey}"
           .replaceAll("\\{" + "searchKey" + "\\}", searchKey.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -777,21 +761,21 @@ public class InvoiceApi {
     }
 
     public String uploadCatalogTranslation(final String locale, final String body, final Boolean deleteIfExists, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(locale, "Missing the required parameter 'locale' when calling uploadCatalogTranslation");
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadCatalogTranslation");
+        Preconditions.checkNotNull(locale, "Missing the required parameter 'locale' when calling uploadCatalogTranslation");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadCatalogTranslation");
 
         final String uri = "/1.0/kb/invoices/catalogTranslation/{locale}"
           .replaceAll("\\{" + "locale" + "\\}", locale.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (deleteIfExists != null) {
-            addToMapValues(queryParams, "deleteIfExists", List.of(String.valueOf(deleteIfExists)));
+            queryParams.put("deleteIfExists", String.valueOf(deleteIfExists));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "text/plain");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "text/plain");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -804,19 +788,19 @@ public class InvoiceApi {
     }
 
     public String uploadInvoiceMPTemplate(final String body, final Boolean deleteIfExists, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadInvoiceMPTemplate");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadInvoiceMPTemplate");
 
         final String uri = "/1.0/kb/invoices/manualPayTemplate";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (deleteIfExists != null) {
-            addToMapValues(queryParams, "deleteIfExists", List.of(String.valueOf(deleteIfExists)));
+            queryParams.put("deleteIfExists", String.valueOf(deleteIfExists));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "text/html");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "text/html");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -829,19 +813,19 @@ public class InvoiceApi {
     }
 
     public String uploadInvoiceTemplate(final String body, final Boolean deleteIfExists, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadInvoiceTemplate");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadInvoiceTemplate");
 
         final String uri = "/1.0/kb/invoices/template";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (deleteIfExists != null) {
-            addToMapValues(queryParams, "deleteIfExists", List.of(String.valueOf(deleteIfExists)));
+            queryParams.put("deleteIfExists", String.valueOf(deleteIfExists));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "text/html");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "text/html");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -854,21 +838,21 @@ public class InvoiceApi {
     }
 
     public String uploadInvoiceTranslation(final String locale, final String body, final Boolean deleteIfExists, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(locale, "Missing the required parameter 'locale' when calling uploadInvoiceTranslation");
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadInvoiceTranslation");
+        Preconditions.checkNotNull(locale, "Missing the required parameter 'locale' when calling uploadInvoiceTranslation");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadInvoiceTranslation");
 
         final String uri = "/1.0/kb/invoices/translation/{locale}"
           .replaceAll("\\{" + "locale" + "\\}", locale.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (deleteIfExists != null) {
-            addToMapValues(queryParams, "deleteIfExists", List.of(String.valueOf(deleteIfExists)));
+            queryParams.put("deleteIfExists", String.valueOf(deleteIfExists));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "text/plain");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "text/plain");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -877,7 +861,7 @@ public class InvoiceApi {
     }
 
     public void voidInvoice(final UUID invoiceId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling voidInvoice");
+        Preconditions.checkNotNull(invoiceId, "Missing the required parameter 'invoiceId' when calling voidInvoice");
 
         final String uri = "/1.0/kb/invoices/{invoiceId}/voidInvoice"
           .replaceAll("\\{" + "invoiceId" + "\\}", invoiceId.toString());

--- a/src/main/java/org/killbill/billing/client/api/gen/InvoiceItemApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/InvoiceItemApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -42,6 +38,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -61,24 +60,9 @@ public class InvoiceItemApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public CustomFields createInvoiceItemCustomFields(final UUID invoiceItemId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling createInvoiceItemCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceItemCustomFields");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling createInvoiceItemCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceItemCustomFields");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/customFields"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
@@ -95,8 +79,8 @@ public class InvoiceItemApi {
     }
 
     public Tags createInvoiceItemTags(final UUID invoiceItemId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling createInvoiceItemTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceItemTags");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling createInvoiceItemTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createInvoiceItemTags");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/tags"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
@@ -114,18 +98,18 @@ public class InvoiceItemApi {
 
 
     public void deleteInvoiceItemCustomFields(final UUID invoiceItemId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling deleteInvoiceItemCustomFields");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling deleteInvoiceItemCustomFields");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/customFields"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -135,18 +119,18 @@ public class InvoiceItemApi {
 
 
     public void deleteInvoiceItemTags(final UUID invoiceItemId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling deleteInvoiceItemTags");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling deleteInvoiceItemTags");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/tags"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -155,7 +139,7 @@ public class InvoiceItemApi {
     }
 
     public AuditLogs getInvoiceItemAuditLogsWithHistory(final UUID invoiceItemId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling getInvoiceItemAuditLogsWithHistory");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling getInvoiceItemAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/auditLogsWithHistory"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
@@ -173,18 +157,18 @@ public class InvoiceItemApi {
     }
 
     public CustomFields getInvoiceItemCustomFields(final UUID invoiceItemId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling getInvoiceItemCustomFields");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling getInvoiceItemCustomFields");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/customFields"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -196,25 +180,25 @@ public class InvoiceItemApi {
     }
 
     public Tags getInvoiceItemTags(final UUID invoiceItemId, final UUID accountId, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling getInvoiceItemTags");
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoiceItemTags");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling getInvoiceItemTags");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling getInvoiceItemTags");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/tags"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (accountId != null) {
-            addToMapValues(queryParams, "accountId", List.of(String.valueOf(accountId)));
+            queryParams.put("accountId", String.valueOf(accountId));
         }
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -222,8 +206,8 @@ public class InvoiceItemApi {
     }
 
     public void modifyInvoiceItemCustomFields(final UUID invoiceItemId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling modifyInvoiceItemCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyInvoiceItemCustomFields");
+        Preconditions.checkNotNull(invoiceItemId, "Missing the required parameter 'invoiceItemId' when calling modifyInvoiceItemCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyInvoiceItemCustomFields");
 
         final String uri = "/1.0/kb/invoiceItems/{invoiceItemId}/customFields"
           .replaceAll("\\{" + "invoiceItemId" + "\\}", invoiceItemId.toString());

--- a/src/main/java/org/killbill/billing/client/api/gen/InvoicePaymentApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/InvoicePaymentApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -46,6 +42,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -65,38 +64,23 @@ public class InvoicePaymentApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public void completeInvoicePaymentTransaction(final UUID paymentId, final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling completeInvoicePaymentTransaction");
-        checkNotNull(body, "Missing the required parameter 'body' when calling completeInvoicePaymentTransaction");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling completeInvoicePaymentTransaction");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling completeInvoicePaymentTransaction");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -105,21 +89,21 @@ public class InvoicePaymentApi {
     }
 
     public InvoicePayment createChargeback(final UUID paymentId, final InvoicePaymentTransaction body, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createChargeback");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createChargeback");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createChargeback");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createChargeback");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/chargebacks"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -128,21 +112,21 @@ public class InvoicePaymentApi {
     }
 
     public InvoicePayment createChargebackReversal(final UUID paymentId, final InvoicePaymentTransaction body, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createChargebackReversal");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createChargebackReversal");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createChargebackReversal");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createChargebackReversal");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/chargebackReversals"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -151,8 +135,8 @@ public class InvoicePaymentApi {
     }
 
     public CustomFields createInvoicePaymentCustomFields(final UUID paymentId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createInvoicePaymentCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createInvoicePaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createInvoicePaymentCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createInvoicePaymentCustomFields");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
@@ -169,8 +153,8 @@ public class InvoicePaymentApi {
     }
 
     public Tags createInvoicePaymentTags(final UUID paymentId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createInvoicePaymentTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createInvoicePaymentTags");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createInvoicePaymentTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createInvoicePaymentTags");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/tags"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
@@ -191,27 +175,27 @@ public class InvoicePaymentApi {
     }
 
     public InvoicePayment createRefundWithAdjustments(final UUID paymentId, final InvoicePaymentTransaction body, final Boolean externalPayment, final UUID paymentMethodId, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createRefundWithAdjustments");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createRefundWithAdjustments");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createRefundWithAdjustments");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createRefundWithAdjustments");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/refunds"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalPayment != null) {
-            addToMapValues(queryParams, "externalPayment", List.of(String.valueOf(externalPayment)));
+            queryParams.put("externalPayment", String.valueOf(externalPayment));
         }
         if (paymentMethodId != null) {
-            addToMapValues(queryParams, "paymentMethodId", List.of(String.valueOf(paymentMethodId)));
+            queryParams.put("paymentMethodId", String.valueOf(paymentMethodId));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -221,18 +205,18 @@ public class InvoicePaymentApi {
 
 
     public void deleteInvoicePaymentCustomFields(final UUID paymentId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deleteInvoicePaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deleteInvoicePaymentCustomFields");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -242,18 +226,18 @@ public class InvoicePaymentApi {
 
 
     public void deleteInvoicePaymentTags(final UUID paymentId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deleteInvoicePaymentTags");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deleteInvoicePaymentTags");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/tags"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -266,27 +250,27 @@ public class InvoicePaymentApi {
     }
 
     public InvoicePayment getInvoicePayment(final UUID paymentId, final Boolean withPluginInfo, final Boolean withAttempts, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getInvoicePayment");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getInvoicePayment");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -294,7 +278,7 @@ public class InvoicePaymentApi {
     }
 
     public AuditLogs getInvoicePaymentAuditLogsWithHistory(final UUID invoicePaymentId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(invoicePaymentId, "Missing the required parameter 'invoicePaymentId' when calling getInvoicePaymentAuditLogsWithHistory");
+        Preconditions.checkNotNull(invoicePaymentId, "Missing the required parameter 'invoicePaymentId' when calling getInvoicePaymentAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/invoicePayments/{invoicePaymentId}/auditLogsWithHistory"
           .replaceAll("\\{" + "invoicePaymentId" + "\\}", invoicePaymentId.toString());
@@ -312,18 +296,18 @@ public class InvoicePaymentApi {
     }
 
     public CustomFields getInvoicePaymentCustomFields(final UUID paymentId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getInvoicePaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getInvoicePaymentCustomFields");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -335,24 +319,24 @@ public class InvoicePaymentApi {
     }
 
     public Tags getInvoicePaymentTags(final UUID paymentId, final Boolean includedDeleted, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getInvoicePaymentTags");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getInvoicePaymentTags");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/tags"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -360,8 +344,8 @@ public class InvoicePaymentApi {
     }
 
     public void modifyInvoicePaymentCustomFields(final UUID paymentId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling modifyInvoicePaymentCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyInvoicePaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling modifyInvoicePaymentCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyInvoicePaymentCustomFields");
 
         final String uri = "/1.0/kb/invoicePayments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());

--- a/src/main/java/org/killbill/billing/client/api/gen/NodesInfoApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/NodesInfoApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.NodeCommand;
@@ -37,6 +33,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -56,21 +55,6 @@ public class NodesInfoApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public PluginInfos getNodesInfo(final RequestOptions inputOptions) throws KillBillClientException {
 
         final String uri = "/1.0/kb/nodesInfo";
@@ -88,19 +72,19 @@ public class NodesInfoApi {
     }
 
     public void triggerNodeCommand(final NodeCommand body, final Boolean localNodeOnly, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling triggerNodeCommand");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling triggerNodeCommand");
 
         final String uri = "/1.0/kb/nodesInfo";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (localNodeOnly != null) {
-            addToMapValues(queryParams, "localNodeOnly", List.of(String.valueOf(localNodeOnly)));
+            queryParams.put("localNodeOnly", String.valueOf(localNodeOnly));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();

--- a/src/main/java/org/killbill/billing/client/api/gen/OverdueApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/OverdueApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.Overdue;
@@ -34,6 +30,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -51,21 +50,6 @@ public class OverdueApi {
 
     public OverdueApi(final KillBillHttpClient httpClient) {
         this.httpClient = httpClient;
-    }
-
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
     }
 
     public Overdue getOverdueConfigJson(final RequestOptions inputOptions) throws KillBillClientException {
@@ -93,7 +77,7 @@ public class OverdueApi {
     }
 
     public Overdue uploadOverdueConfigJson(final Overdue body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadOverdueConfigJson");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadOverdueConfigJson");
 
         final String uri = "/1.0/kb/overdue";
 
@@ -109,7 +93,7 @@ public class OverdueApi {
     }
 
     public String uploadOverdueConfigXml(final String body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadOverdueConfigXml");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadOverdueConfigXml");
 
         final String uri = "/1.0/kb/overdue/xml";
 

--- a/src/main/java/org/killbill/billing/client/api/gen/PaymentApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/PaymentApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -47,6 +43,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -66,34 +65,19 @@ public class PaymentApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
 
     public void cancelScheduledPaymentTransactionByExternalKey(final String transactionExternalKey, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionExternalKey, "Missing the required parameter 'transactionExternalKey' when calling cancelScheduledPaymentTransactionByExternalKey");
+        Preconditions.checkNotNull(transactionExternalKey, "Missing the required parameter 'transactionExternalKey' when calling cancelScheduledPaymentTransactionByExternalKey");
 
         final String uri = "/1.0/kb/payments/cancelScheduledPaymentTransaction";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (transactionExternalKey != null) {
-            addToMapValues(queryParams, "transactionExternalKey", List.of(String.valueOf(transactionExternalKey)));
+            queryParams.put("transactionExternalKey", String.valueOf(transactionExternalKey));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -103,7 +87,7 @@ public class PaymentApi {
 
 
     public void cancelScheduledPaymentTransactionById(final UUID paymentTransactionId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentTransactionId, "Missing the required parameter 'paymentTransactionId' when calling cancelScheduledPaymentTransactionById");
+        Preconditions.checkNotNull(paymentTransactionId, "Missing the required parameter 'paymentTransactionId' when calling cancelScheduledPaymentTransactionById");
 
         final String uri = "/1.0/kb/payments/{paymentTransactionId}/cancelScheduledPaymentTransaction"
           .replaceAll("\\{" + "paymentTransactionId" + "\\}", paymentTransactionId.toString());
@@ -118,24 +102,24 @@ public class PaymentApi {
     }
 
     public Payment captureAuthorization(final UUID paymentId, final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling captureAuthorization");
-        checkNotNull(body, "Missing the required parameter 'body' when calling captureAuthorization");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling captureAuthorization");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling captureAuthorization");
 
         final String uri = "/1.0/kb/payments/{paymentId}"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -144,22 +128,22 @@ public class PaymentApi {
     }
 
     public Payment captureAuthorizationByExternalKey(final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling captureAuthorizationByExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling captureAuthorizationByExternalKey");
 
         final String uri = "/1.0/kb/payments";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -168,24 +152,24 @@ public class PaymentApi {
     }
 
     public Payment chargebackPayment(final UUID paymentId, final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling chargebackPayment");
-        checkNotNull(body, "Missing the required parameter 'body' when calling chargebackPayment");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling chargebackPayment");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling chargebackPayment");
 
         final String uri = "/1.0/kb/payments/{paymentId}/chargebacks"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -194,22 +178,22 @@ public class PaymentApi {
     }
 
     public Payment chargebackPaymentByExternalKey(final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling chargebackPaymentByExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling chargebackPaymentByExternalKey");
 
         final String uri = "/1.0/kb/payments/chargebacks";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -218,24 +202,24 @@ public class PaymentApi {
     }
 
     public Payment chargebackReversalPayment(final UUID paymentId, final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling chargebackReversalPayment");
-        checkNotNull(body, "Missing the required parameter 'body' when calling chargebackReversalPayment");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling chargebackReversalPayment");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling chargebackReversalPayment");
 
         final String uri = "/1.0/kb/payments/{paymentId}/chargebackReversals"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -244,22 +228,22 @@ public class PaymentApi {
     }
 
     public Payment chargebackReversalPaymentByExternalKey(final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling chargebackReversalPaymentByExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling chargebackReversalPaymentByExternalKey");
 
         final String uri = "/1.0/kb/payments/chargebackReversals";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -268,22 +252,22 @@ public class PaymentApi {
     }
 
     public void completeTransaction(final UUID paymentId, final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling completeTransaction");
-        checkNotNull(body, "Missing the required parameter 'body' when calling completeTransaction");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling completeTransaction");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling completeTransaction");
 
         final String uri = "/1.0/kb/payments/{paymentId}"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -292,20 +276,20 @@ public class PaymentApi {
     }
 
     public void completeTransactionByExternalKey(final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling completeTransactionByExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling completeTransactionByExternalKey");
 
         final String uri = "/1.0/kb/payments";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -314,19 +298,19 @@ public class PaymentApi {
     }
 
     public Payment createComboPayment(final ComboPaymentTransaction body, final List<String> controlPluginName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createComboPayment");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createComboPayment");
 
         final String uri = "/1.0/kb/payments/combo";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -335,8 +319,8 @@ public class PaymentApi {
     }
 
     public CustomFields createPaymentCustomFields(final UUID paymentId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createPaymentCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createPaymentCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentCustomFields");
 
         final String uri = "/1.0/kb/payments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
@@ -353,8 +337,8 @@ public class PaymentApi {
     }
 
     public Tags createPaymentTags(final UUID paymentId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createPaymentTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentTags");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling createPaymentTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentTags");
 
         final String uri = "/1.0/kb/payments/{paymentId}/tags"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
@@ -372,18 +356,18 @@ public class PaymentApi {
 
 
     public void deletePaymentCustomFields(final UUID paymentId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deletePaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deletePaymentCustomFields");
 
         final String uri = "/1.0/kb/payments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -393,18 +377,18 @@ public class PaymentApi {
 
 
     public void deletePaymentTags(final UUID paymentId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deletePaymentTags");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling deletePaymentTags");
 
         final String uri = "/1.0/kb/payments/{paymentId}/tags"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -417,27 +401,27 @@ public class PaymentApi {
     }
 
     public Payment getPayment(final UUID paymentId, final Boolean withPluginInfo, final Boolean withAttempts, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPayment");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPayment");
 
         final String uri = "/1.0/kb/payments/{paymentId}"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -445,7 +429,7 @@ public class PaymentApi {
     }
 
     public AuditLogs getPaymentAttemptAuditLogsWithHistory(final UUID paymentAttemptId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentAttemptId, "Missing the required parameter 'paymentAttemptId' when calling getPaymentAttemptAuditLogsWithHistory");
+        Preconditions.checkNotNull(paymentAttemptId, "Missing the required parameter 'paymentAttemptId' when calling getPaymentAttemptAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/payments/attempts/{paymentAttemptId}/auditLogsWithHistory"
           .replaceAll("\\{" + "paymentAttemptId" + "\\}", paymentAttemptId.toString());
@@ -459,7 +443,7 @@ public class PaymentApi {
     }
 
     public AuditLogs getPaymentAuditLogsWithHistory(final UUID paymentId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPaymentAuditLogsWithHistory");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPaymentAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/payments/{paymentId}/auditLogsWithHistory"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
@@ -477,29 +461,29 @@ public class PaymentApi {
     }
 
     public Payment getPaymentByExternalKey(final String externalKey, final Boolean withPluginInfo, final Boolean withAttempts, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getPaymentByExternalKey");
+        Preconditions.checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getPaymentByExternalKey");
 
         final String uri = "/1.0/kb/payments";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (externalKey != null) {
-            addToMapValues(queryParams, "externalKey", List.of(String.valueOf(externalKey)));
+            queryParams.put("externalKey", String.valueOf(externalKey));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -511,18 +495,18 @@ public class PaymentApi {
     }
 
     public CustomFields getPaymentCustomFields(final UUID paymentId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPaymentCustomFields");
 
         final String uri = "/1.0/kb/payments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -534,21 +518,21 @@ public class PaymentApi {
     }
 
     public Tags getPaymentTags(final UUID paymentId, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPaymentTags");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling getPaymentTags");
 
         final String uri = "/1.0/kb/payments/{paymentId}/tags"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -563,31 +547,31 @@ public class PaymentApi {
 
         final String uri = "/1.0/kb/payments/pagination";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (pluginName != null) {
-            addToMapValues(queryParams, "pluginName", List.of(String.valueOf(pluginName)));
+            queryParams.put("pluginName", String.valueOf(pluginName));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -595,8 +579,8 @@ public class PaymentApi {
     }
 
     public void modifyPaymentCustomFields(final UUID paymentId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling modifyPaymentCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyPaymentCustomFields");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling modifyPaymentCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyPaymentCustomFields");
 
         final String uri = "/1.0/kb/payments/{paymentId}/customFields"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
@@ -611,24 +595,24 @@ public class PaymentApi {
     }
 
     public Payment refundPayment(final UUID paymentId, final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling refundPayment");
-        checkNotNull(body, "Missing the required parameter 'body' when calling refundPayment");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling refundPayment");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling refundPayment");
 
         final String uri = "/1.0/kb/payments/{paymentId}/refunds"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -637,22 +621,22 @@ public class PaymentApi {
     }
 
     public Payment refundPaymentByExternalKey(final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling refundPaymentByExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling refundPaymentByExternalKey");
 
         final String uri = "/1.0/kb/payments/refunds";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -665,36 +649,36 @@ public class PaymentApi {
     }
 
     public Payments searchPayments(final String searchKey, final Long offset, final Long limit, final Boolean withPluginInfo, final Boolean withAttempts, final String pluginName, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchPayments");
+        Preconditions.checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchPayments");
 
         final String uri = "/1.0/kb/payments/search/{searchKey}"
           .replaceAll("\\{" + "searchKey" + "\\}", searchKey.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (pluginName != null) {
-            addToMapValues(queryParams, "pluginName", List.of(String.valueOf(pluginName)));
+            queryParams.put("pluginName", String.valueOf(pluginName));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -703,22 +687,22 @@ public class PaymentApi {
 
 
     public void voidPayment(final UUID paymentId, final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling voidPayment");
-        checkNotNull(body, "Missing the required parameter 'body' when calling voidPayment");
+        Preconditions.checkNotNull(paymentId, "Missing the required parameter 'paymentId' when calling voidPayment");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling voidPayment");
 
         final String uri = "/1.0/kb/payments/{paymentId}"
           .replaceAll("\\{" + "paymentId" + "\\}", paymentId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -728,20 +712,20 @@ public class PaymentApi {
 
 
     public void voidPaymentByExternalKey(final PaymentTransaction body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling voidPaymentByExternalKey");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling voidPaymentByExternalKey");
 
         final String uri = "/1.0/kb/payments";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();

--- a/src/main/java/org/killbill/billing/client/api/gen/PaymentGatewayApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/PaymentGatewayApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.ComboHostedPaymentPage;
@@ -39,6 +35,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -58,38 +57,23 @@ public class PaymentGatewayApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public HostedPaymentPageFormDescriptor buildComboFormDescriptor(final ComboHostedPaymentPage body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling buildComboFormDescriptor");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling buildComboFormDescriptor");
 
         final String uri = "/1.0/kb/paymentGateways/hosted/form";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -98,27 +82,27 @@ public class PaymentGatewayApi {
     }
 
     public HostedPaymentPageFormDescriptor buildFormDescriptor(final UUID accountId, final HostedPaymentPageFields body, final UUID paymentMethodId, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(accountId, "Missing the required parameter 'accountId' when calling buildFormDescriptor");
-        checkNotNull(body, "Missing the required parameter 'body' when calling buildFormDescriptor");
+        Preconditions.checkNotNull(accountId, "Missing the required parameter 'accountId' when calling buildFormDescriptor");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling buildFormDescriptor");
 
         final String uri = "/1.0/kb/paymentGateways/hosted/form/{accountId}"
           .replaceAll("\\{" + "accountId" + "\\}", accountId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (paymentMethodId != null) {
-            addToMapValues(queryParams, "paymentMethodId", List.of(String.valueOf(paymentMethodId)));
+            queryParams.put("paymentMethodId", String.valueOf(paymentMethodId));
         }
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -127,24 +111,24 @@ public class PaymentGatewayApi {
     }
 
     public void processNotification(final String pluginName, final String body, final List<String> controlPluginName, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling processNotification");
-        checkNotNull(body, "Missing the required parameter 'body' when calling processNotification");
+        Preconditions.checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling processNotification");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling processNotification");
 
         final String uri = "/1.0/kb/paymentGateways/notification/{pluginName}"
           .replaceAll("\\{" + "pluginName" + "\\}", pluginName.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "*/*");
         final RequestOptions requestOptions = inputOptionsBuilder.build();

--- a/src/main/java/org/killbill/billing/client/api/gen/PaymentMethodApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/PaymentMethodApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -43,6 +39,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -62,24 +61,9 @@ public class PaymentMethodApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public CustomFields createPaymentMethodCustomFields(final UUID paymentMethodId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling createPaymentMethodCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentMethodCustomFields");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling createPaymentMethodCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createPaymentMethodCustomFields");
 
         final String uri = "/1.0/kb/paymentMethods/{paymentMethodId}/customFields"
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
@@ -101,24 +85,24 @@ public class PaymentMethodApi {
 
 
     public void deletePaymentMethod(final UUID paymentMethodId, final Boolean deleteDefaultPmWithAutoPayOff, final Boolean forceDefaultPmDeletion, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling deletePaymentMethod");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling deletePaymentMethod");
 
         final String uri = "/1.0/kb/paymentMethods/{paymentMethodId}"
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (deleteDefaultPmWithAutoPayOff != null) {
-            addToMapValues(queryParams, "deleteDefaultPmWithAutoPayOff", List.of(String.valueOf(deleteDefaultPmWithAutoPayOff)));
+            queryParams.put("deleteDefaultPmWithAutoPayOff", String.valueOf(deleteDefaultPmWithAutoPayOff));
         }
         if (forceDefaultPmDeletion != null) {
-            addToMapValues(queryParams, "forceDefaultPmDeletion", List.of(String.valueOf(forceDefaultPmDeletion)));
+            queryParams.put("forceDefaultPmDeletion", String.valueOf(forceDefaultPmDeletion));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -127,18 +111,18 @@ public class PaymentMethodApi {
 
 
     public void deletePaymentMethodCustomFields(final UUID paymentMethodId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling deletePaymentMethodCustomFields");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling deletePaymentMethodCustomFields");
 
         final String uri = "/1.0/kb/paymentMethods/{paymentMethodId}/customFields"
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -151,27 +135,27 @@ public class PaymentMethodApi {
     }
 
     public PaymentMethod getPaymentMethod(final UUID paymentMethodId, final Boolean includedDeleted, final Boolean withPluginInfo, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling getPaymentMethod");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling getPaymentMethod");
 
         final String uri = "/1.0/kb/paymentMethods/{paymentMethodId}"
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -179,7 +163,7 @@ public class PaymentMethodApi {
     }
 
     public AuditLogs getPaymentMethodAuditLogsWithHistory(final UUID paymentMethodId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling getPaymentMethodAuditLogsWithHistory");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling getPaymentMethodAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/paymentMethods/{paymentMethodId}/auditLogsWithHistory"
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
@@ -197,29 +181,29 @@ public class PaymentMethodApi {
     }
 
     public PaymentMethod getPaymentMethodByKey(final String externalKey, final Boolean includedDeleted, final Boolean withPluginInfo, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getPaymentMethodByKey");
+        Preconditions.checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getPaymentMethodByKey");
 
         final String uri = "/1.0/kb/paymentMethods";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalKey != null) {
-            addToMapValues(queryParams, "externalKey", List.of(String.valueOf(externalKey)));
+            queryParams.put("externalKey", String.valueOf(externalKey));
         }
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -231,18 +215,18 @@ public class PaymentMethodApi {
     }
 
     public CustomFields getPaymentMethodCustomFields(final UUID paymentMethodId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling getPaymentMethodCustomFields");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling getPaymentMethodCustomFields");
 
         final String uri = "/1.0/kb/paymentMethods/{paymentMethodId}/customFields"
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -257,28 +241,28 @@ public class PaymentMethodApi {
 
         final String uri = "/1.0/kb/paymentMethods/pagination";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (pluginName != null) {
-            addToMapValues(queryParams, "pluginName", List.of(String.valueOf(pluginName)));
+            queryParams.put("pluginName", String.valueOf(pluginName));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -286,8 +270,8 @@ public class PaymentMethodApi {
     }
 
     public void modifyPaymentMethodCustomFields(final UUID paymentMethodId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling modifyPaymentMethodCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyPaymentMethodCustomFields");
+        Preconditions.checkNotNull(paymentMethodId, "Missing the required parameter 'paymentMethodId' when calling modifyPaymentMethodCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyPaymentMethodCustomFields");
 
         final String uri = "/1.0/kb/paymentMethods/{paymentMethodId}/customFields"
           .replaceAll("\\{" + "paymentMethodId" + "\\}", paymentMethodId.toString());
@@ -306,33 +290,33 @@ public class PaymentMethodApi {
     }
 
     public PaymentMethods searchPaymentMethods(final String searchKey, final Long offset, final Long limit, final String pluginName, final Boolean withPluginInfo, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchPaymentMethods");
+        Preconditions.checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchPaymentMethods");
 
         final String uri = "/1.0/kb/paymentMethods/search/{searchKey}"
           .replaceAll("\\{" + "searchKey" + "\\}", searchKey.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (pluginName != null) {
-            addToMapValues(queryParams, "pluginName", List.of(String.valueOf(pluginName)));
+            queryParams.put("pluginName", String.valueOf(pluginName));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 

--- a/src/main/java/org/killbill/billing/client/api/gen/PaymentTransactionApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/PaymentTransactionApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -45,6 +41,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -64,24 +63,9 @@ public class PaymentTransactionApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public CustomFields createTransactionCustomFields(final UUID transactionId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling createTransactionCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createTransactionCustomFields");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling createTransactionCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createTransactionCustomFields");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/customFields"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
@@ -98,8 +82,8 @@ public class PaymentTransactionApi {
     }
 
     public Tags createTransactionTags(final UUID transactionId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling createTransactionTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createTransactionTags");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling createTransactionTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createTransactionTags");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/tags"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
@@ -117,18 +101,18 @@ public class PaymentTransactionApi {
 
 
     public void deleteTransactionCustomFields(final UUID transactionId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling deleteTransactionCustomFields");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling deleteTransactionCustomFields");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/customFields"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -138,18 +122,18 @@ public class PaymentTransactionApi {
 
 
     public void deleteTransactionTags(final UUID transactionId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling deleteTransactionTags");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling deleteTransactionTags");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/tags"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -162,29 +146,29 @@ public class PaymentTransactionApi {
     }
 
     public Payment getPaymentByTransactionExternalKey(final String transactionExternalKey, final Boolean withPluginInfo, final Boolean withAttempts, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionExternalKey, "Missing the required parameter 'transactionExternalKey' when calling getPaymentByTransactionExternalKey");
+        Preconditions.checkNotNull(transactionExternalKey, "Missing the required parameter 'transactionExternalKey' when calling getPaymentByTransactionExternalKey");
 
         final String uri = "/1.0/kb/paymentTransactions";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (transactionExternalKey != null) {
-            addToMapValues(queryParams, "transactionExternalKey", List.of(String.valueOf(transactionExternalKey)));
+            queryParams.put("transactionExternalKey", String.valueOf(transactionExternalKey));
         }
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -196,27 +180,27 @@ public class PaymentTransactionApi {
     }
 
     public Payment getPaymentByTransactionId(final UUID transactionId, final Boolean withPluginInfo, final Boolean withAttempts, final Map<String, String> pluginProperty, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getPaymentByTransactionId");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getPaymentByTransactionId");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (withPluginInfo != null) {
-            addToMapValues(queryParams, "withPluginInfo", List.of(String.valueOf(withPluginInfo)));
+            queryParams.put("withPluginInfo", String.valueOf(withPluginInfo));
         }
         if (withAttempts != null) {
-            addToMapValues(queryParams, "withAttempts", List.of(String.valueOf(withAttempts)));
+            queryParams.put("withAttempts", String.valueOf(withAttempts));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -224,7 +208,7 @@ public class PaymentTransactionApi {
     }
 
     public AuditLogs getTransactionAuditLogsWithHistory(final UUID transactionId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getTransactionAuditLogsWithHistory");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getTransactionAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/auditLogsWithHistory"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
@@ -242,18 +226,18 @@ public class PaymentTransactionApi {
     }
 
     public CustomFields getTransactionCustomFields(final UUID transactionId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getTransactionCustomFields");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getTransactionCustomFields");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/customFields"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -265,21 +249,21 @@ public class PaymentTransactionApi {
     }
 
     public Tags getTransactionTags(final UUID transactionId, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getTransactionTags");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling getTransactionTags");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/tags"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -287,8 +271,8 @@ public class PaymentTransactionApi {
     }
 
     public void modifyTransactionCustomFields(final UUID transactionId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling modifyTransactionCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifyTransactionCustomFields");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling modifyTransactionCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifyTransactionCustomFields");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}/customFields"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
@@ -303,21 +287,21 @@ public class PaymentTransactionApi {
     }
 
     public Payment notifyStateChanged(final UUID transactionId, final PaymentTransaction body, final List<String> controlPluginName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling notifyStateChanged");
-        checkNotNull(body, "Missing the required parameter 'body' when calling notifyStateChanged");
+        Preconditions.checkNotNull(transactionId, "Missing the required parameter 'transactionId' when calling notifyStateChanged");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling notifyStateChanged");
 
         final String uri = "/1.0/kb/paymentTransactions/{transactionId}"
           .replaceAll("\\{" + "transactionId" + "\\}", transactionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (controlPluginName != null) {
-            addToMapValues(queryParams, "controlPluginName", controlPluginName);
+            queryParams.putAll("controlPluginName", controlPluginName);
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();

--- a/src/main/java/org/killbill/billing/client/api/gen/PluginInfoApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/PluginInfoApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.PluginInfo;
@@ -36,6 +32,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -53,21 +52,6 @@ public class PluginInfoApi {
 
     public PluginInfoApi(final KillBillHttpClient httpClient) {
         this.httpClient = httpClient;
-    }
-
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
     }
 
     public PluginInfos getPluginsInfo(final RequestOptions inputOptions) throws KillBillClientException {

--- a/src/main/java/org/killbill/billing/client/api/gen/SecurityApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/SecurityApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.RoleDefinition;
@@ -38,6 +34,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -57,23 +56,8 @@ public class SecurityApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public RoleDefinition addRoleDefinition(final RoleDefinition body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling addRoleDefinition");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addRoleDefinition");
 
         final String uri = "/1.0/kb/security/roles";
 
@@ -89,7 +73,7 @@ public class SecurityApi {
     }
 
     public UserRoles addUserRoles(final UserRoles body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling addUserRoles");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addUserRoles");
 
         final String uri = "/1.0/kb/security/users";
 
@@ -129,7 +113,7 @@ public class SecurityApi {
     }
 
     public RoleDefinition getRoleDefinition(final String role, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(role, "Missing the required parameter 'role' when calling getRoleDefinition");
+        Preconditions.checkNotNull(role, "Missing the required parameter 'role' when calling getRoleDefinition");
 
         final String uri = "/1.0/kb/security/roles/{role}"
           .replaceAll("\\{" + "role" + "\\}", role.toString());
@@ -143,7 +127,7 @@ public class SecurityApi {
     }
 
     public UserRoles getUserRoles(final String username, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(username, "Missing the required parameter 'username' when calling getUserRoles");
+        Preconditions.checkNotNull(username, "Missing the required parameter 'username' when calling getUserRoles");
 
         final String uri = "/1.0/kb/security/users/{username}/roles"
           .replaceAll("\\{" + "username" + "\\}", username.toString());
@@ -158,7 +142,7 @@ public class SecurityApi {
 
 
     public void invalidateUser(final String username, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(username, "Missing the required parameter 'username' when calling invalidateUser");
+        Preconditions.checkNotNull(username, "Missing the required parameter 'username' when calling invalidateUser");
 
         final String uri = "/1.0/kb/security/users/{username}"
           .replaceAll("\\{" + "username" + "\\}", username.toString());
@@ -173,7 +157,7 @@ public class SecurityApi {
     }
 
     public void updateRoleDefinition(final RoleDefinition body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling updateRoleDefinition");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling updateRoleDefinition");
 
         final String uri = "/1.0/kb/security/roles";
 
@@ -187,8 +171,8 @@ public class SecurityApi {
     }
 
     public void updateUserPassword(final String username, final UserRoles body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(username, "Missing the required parameter 'username' when calling updateUserPassword");
-        checkNotNull(body, "Missing the required parameter 'body' when calling updateUserPassword");
+        Preconditions.checkNotNull(username, "Missing the required parameter 'username' when calling updateUserPassword");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling updateUserPassword");
 
         final String uri = "/1.0/kb/security/users/{username}/password"
           .replaceAll("\\{" + "username" + "\\}", username.toString());
@@ -203,8 +187,8 @@ public class SecurityApi {
     }
 
     public void updateUserRoles(final String username, final UserRoles body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(username, "Missing the required parameter 'username' when calling updateUserRoles");
-        checkNotNull(body, "Missing the required parameter 'body' when calling updateUserRoles");
+        Preconditions.checkNotNull(username, "Missing the required parameter 'username' when calling updateUserRoles");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling updateUserRoles");
 
         final String uri = "/1.0/kb/security/users/{username}/roles"
           .replaceAll("\\{" + "username" + "\\}", username.toString());

--- a/src/main/java/org/killbill/billing/client/api/gen/SubscriptionApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/SubscriptionApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -55,6 +51,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -74,40 +73,25 @@ public class SubscriptionApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public BlockingStates addSubscriptionBlockingState(final UUID subscriptionId, final BlockingState body, final LocalDate requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling addSubscriptionBlockingState");
-        checkNotNull(body, "Missing the required parameter 'body' when calling addSubscriptionBlockingState");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling addSubscriptionBlockingState");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addSubscriptionBlockingState");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/block"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -115,24 +99,24 @@ public class SubscriptionApi {
     }
 
     public BlockingStates addSubscriptionBlockingState(final UUID subscriptionId, final BlockingState body, final DateTime requestedDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling addSubscriptionBlockingState");
-        checkNotNull(body, "Missing the required parameter 'body' when calling addSubscriptionBlockingState");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling addSubscriptionBlockingState");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling addSubscriptionBlockingState");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/block"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -145,36 +129,36 @@ public class SubscriptionApi {
 
 
     public void cancelSubscriptionPlan(final UUID subscriptionId, final LocalDate requestedDate, final Boolean callCompletion, final Long callTimeoutSec, final EntitlementActionPolicy entitlementPolicy, final BillingActionPolicy billingPolicy, final Boolean useRequestedDateForBilling, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling cancelSubscriptionPlan");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling cancelSubscriptionPlan");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (entitlementPolicy != null) {
-            addToMapValues(queryParams, "entitlementPolicy", List.of(String.valueOf(entitlementPolicy)));
+            queryParams.put("entitlementPolicy", String.valueOf(entitlementPolicy));
         }
         if (billingPolicy != null) {
-            addToMapValues(queryParams, "billingPolicy", List.of(String.valueOf(billingPolicy)));
+            queryParams.put("billingPolicy", String.valueOf(billingPolicy));
         }
         if (useRequestedDateForBilling != null) {
-            addToMapValues(queryParams, "useRequestedDateForBilling", List.of(String.valueOf(useRequestedDateForBilling)));
+            queryParams.put("useRequestedDateForBilling", String.valueOf(useRequestedDateForBilling));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -187,36 +171,36 @@ public class SubscriptionApi {
 
 
     public void cancelSubscriptionPlan(final UUID subscriptionId, final DateTime requestedDate, final Boolean callCompletion, final Long callTimeoutSec, final EntitlementActionPolicy entitlementPolicy, final BillingActionPolicy billingPolicy, final Boolean useRequestedDateForBilling, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling cancelSubscriptionPlan");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling cancelSubscriptionPlan");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (entitlementPolicy != null) {
-            addToMapValues(queryParams, "entitlementPolicy", List.of(String.valueOf(entitlementPolicy)));
+            queryParams.put("entitlementPolicy", String.valueOf(entitlementPolicy));
         }
         if (billingPolicy != null) {
-            addToMapValues(queryParams, "billingPolicy", List.of(String.valueOf(billingPolicy)));
+            queryParams.put("billingPolicy", String.valueOf(billingPolicy));
         }
         if (useRequestedDateForBilling != null) {
-            addToMapValues(queryParams, "useRequestedDateForBilling", List.of(String.valueOf(useRequestedDateForBilling)));
+            queryParams.put("useRequestedDateForBilling", String.valueOf(useRequestedDateForBilling));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -228,31 +212,31 @@ public class SubscriptionApi {
     }
 
     public void changeSubscriptionPlan(final UUID subscriptionId, final Subscription body, final LocalDate requestedDate, final Boolean callCompletion, final Long callTimeoutSec, final BillingActionPolicy billingPolicy, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling changeSubscriptionPlan");
-        checkNotNull(body, "Missing the required parameter 'body' when calling changeSubscriptionPlan");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling changeSubscriptionPlan");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling changeSubscriptionPlan");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (billingPolicy != null) {
-            addToMapValues(queryParams, "billingPolicy", List.of(String.valueOf(billingPolicy)));
+            queryParams.put("billingPolicy", String.valueOf(billingPolicy));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -265,31 +249,31 @@ public class SubscriptionApi {
     }
 
     public void changeSubscriptionPlan(final UUID subscriptionId, final Subscription body, final DateTime requestedDate, final Boolean callCompletion, final Long callTimeoutSec, final BillingActionPolicy billingPolicy, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling changeSubscriptionPlan");
-        checkNotNull(body, "Missing the required parameter 'body' when calling changeSubscriptionPlan");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling changeSubscriptionPlan");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling changeSubscriptionPlan");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (requestedDate != null) {
-            addToMapValues(queryParams, "requestedDate", List.of(String.valueOf(requestedDate)));
+            queryParams.put("requestedDate", String.valueOf(requestedDate));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (billingPolicy != null) {
-            addToMapValues(queryParams, "billingPolicy", List.of(String.valueOf(billingPolicy)));
+            queryParams.put("billingPolicy", String.valueOf(billingPolicy));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -302,40 +286,40 @@ public class SubscriptionApi {
     }
 
     public Subscription createSubscription(final Subscription body, final LocalDate entitlementDate, final LocalDate billingDate, final Boolean renameKeyIfExistsAndUnused, final Boolean migrated, final Boolean skipResponse, final Boolean callCompletion, final Long callTimeoutSec, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createSubscription");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createSubscription");
 
         final String uri = "/1.0/kb/subscriptions";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (entitlementDate != null) {
-            addToMapValues(queryParams, "entitlementDate", List.of(String.valueOf(entitlementDate)));
+            queryParams.put("entitlementDate", String.valueOf(entitlementDate));
         }
         if (billingDate != null) {
-            addToMapValues(queryParams, "billingDate", List.of(String.valueOf(billingDate)));
+            queryParams.put("billingDate", String.valueOf(billingDate));
         }
         if (renameKeyIfExistsAndUnused != null) {
-            addToMapValues(queryParams, "renameKeyIfExistsAndUnused", List.of(String.valueOf(renameKeyIfExistsAndUnused)));
+            queryParams.put("renameKeyIfExistsAndUnused", String.valueOf(renameKeyIfExistsAndUnused));
         }
         if (migrated != null) {
-            addToMapValues(queryParams, "migrated", List.of(String.valueOf(migrated)));
+            queryParams.put("migrated", String.valueOf(migrated));
         }
         if (skipResponse != null) {
-            addToMapValues(queryParams, "skipResponse", List.of(String.valueOf(skipResponse)));
+            queryParams.put("skipResponse", String.valueOf(skipResponse));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -348,40 +332,40 @@ public class SubscriptionApi {
     }
 
     public Subscription createSubscription(final Subscription body, final DateTime entitlementDate, final DateTime billingDate, final Boolean renameKeyIfExistsAndUnused, final Boolean migrated, final Boolean skipResponse, final Boolean callCompletion, final Long callTimeoutSec, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createSubscription");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createSubscription");
 
         final String uri = "/1.0/kb/subscriptions";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (entitlementDate != null) {
-            addToMapValues(queryParams, "entitlementDate", List.of(String.valueOf(entitlementDate)));
+            queryParams.put("entitlementDate", String.valueOf(entitlementDate));
         }
         if (billingDate != null) {
-            addToMapValues(queryParams, "billingDate", List.of(String.valueOf(billingDate)));
+            queryParams.put("billingDate", String.valueOf(billingDate));
         }
         if (renameKeyIfExistsAndUnused != null) {
-            addToMapValues(queryParams, "renameKeyIfExistsAndUnused", List.of(String.valueOf(renameKeyIfExistsAndUnused)));
+            queryParams.put("renameKeyIfExistsAndUnused", String.valueOf(renameKeyIfExistsAndUnused));
         }
         if (migrated != null) {
-            addToMapValues(queryParams, "migrated", List.of(String.valueOf(migrated)));
+            queryParams.put("migrated", String.valueOf(migrated));
         }
         if (skipResponse != null) {
-            addToMapValues(queryParams, "skipResponse", List.of(String.valueOf(skipResponse)));
+            queryParams.put("skipResponse", String.valueOf(skipResponse));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -390,8 +374,8 @@ public class SubscriptionApi {
     }
 
     public void createSubscriptionCustomFields(final UUID subscriptionId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling createSubscriptionCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionCustomFields");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling createSubscriptionCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionCustomFields");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/customFields"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
@@ -408,8 +392,8 @@ public class SubscriptionApi {
     }
 
     public void createSubscriptionTags(final UUID subscriptionId, final List<UUID> body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling createSubscriptionTags");
-        checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionTags");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling createSubscriptionTags");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionTags");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/tags"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
@@ -430,40 +414,40 @@ public class SubscriptionApi {
     }
 
     public Bundle createSubscriptionWithAddOns(final Subscriptions body, final LocalDate entitlementDate, final LocalDate billingDate, final Boolean migrated, final Boolean skipResponse, final Boolean renameKeyIfExistsAndUnused, final Boolean callCompletion, final Long callTimeoutSec, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionWithAddOns");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionWithAddOns");
 
         final String uri = "/1.0/kb/subscriptions/createSubscriptionWithAddOns";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (entitlementDate != null) {
-            addToMapValues(queryParams, "entitlementDate", List.of(String.valueOf(entitlementDate)));
+            queryParams.put("entitlementDate", String.valueOf(entitlementDate));
         }
         if (billingDate != null) {
-            addToMapValues(queryParams, "billingDate", List.of(String.valueOf(billingDate)));
+            queryParams.put("billingDate", String.valueOf(billingDate));
         }
         if (migrated != null) {
-            addToMapValues(queryParams, "migrated", List.of(String.valueOf(migrated)));
+            queryParams.put("migrated", String.valueOf(migrated));
         }
         if (skipResponse != null) {
-            addToMapValues(queryParams, "skipResponse", List.of(String.valueOf(skipResponse)));
+            queryParams.put("skipResponse", String.valueOf(skipResponse));
         }
         if (renameKeyIfExistsAndUnused != null) {
-            addToMapValues(queryParams, "renameKeyIfExistsAndUnused", List.of(String.valueOf(renameKeyIfExistsAndUnused)));
+            queryParams.put("renameKeyIfExistsAndUnused", String.valueOf(renameKeyIfExistsAndUnused));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -476,40 +460,40 @@ public class SubscriptionApi {
     }
 
     public Bundle createSubscriptionWithAddOns(final Subscriptions body, final DateTime entitlementDate, final DateTime billingDate, final Boolean migrated, final Boolean skipResponse, final Boolean renameKeyIfExistsAndUnused, final Boolean callCompletion, final Long callTimeoutSec, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionWithAddOns");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionWithAddOns");
 
         final String uri = "/1.0/kb/subscriptions/createSubscriptionWithAddOns";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (entitlementDate != null) {
-            addToMapValues(queryParams, "entitlementDate", List.of(String.valueOf(entitlementDate)));
+            queryParams.put("entitlementDate", String.valueOf(entitlementDate));
         }
         if (billingDate != null) {
-            addToMapValues(queryParams, "billingDate", List.of(String.valueOf(billingDate)));
+            queryParams.put("billingDate", String.valueOf(billingDate));
         }
         if (migrated != null) {
-            addToMapValues(queryParams, "migrated", List.of(String.valueOf(migrated)));
+            queryParams.put("migrated", String.valueOf(migrated));
         }
         if (skipResponse != null) {
-            addToMapValues(queryParams, "skipResponse", List.of(String.valueOf(skipResponse)));
+            queryParams.put("skipResponse", String.valueOf(skipResponse));
         }
         if (renameKeyIfExistsAndUnused != null) {
-            addToMapValues(queryParams, "renameKeyIfExistsAndUnused", List.of(String.valueOf(renameKeyIfExistsAndUnused)));
+            queryParams.put("renameKeyIfExistsAndUnused", String.valueOf(renameKeyIfExistsAndUnused));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -522,40 +506,40 @@ public class SubscriptionApi {
     }
 
     public Bundles createSubscriptionsWithAddOns(final BulkSubscriptionsBundles body, final LocalDate entitlementDate, final LocalDate billingDate, final Boolean renameKeyIfExistsAndUnused, final Boolean migrated, final Boolean skipResponse, final Boolean callCompletion, final Long callTimeoutSec, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionsWithAddOns");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createSubscriptionsWithAddOns");
 
         final String uri = "/1.0/kb/subscriptions/createSubscriptionsWithAddOns";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (entitlementDate != null) {
-            addToMapValues(queryParams, "entitlementDate", List.of(String.valueOf(entitlementDate)));
+            queryParams.put("entitlementDate", String.valueOf(entitlementDate));
         }
         if (billingDate != null) {
-            addToMapValues(queryParams, "billingDate", List.of(String.valueOf(billingDate)));
+            queryParams.put("billingDate", String.valueOf(billingDate));
         }
         if (renameKeyIfExistsAndUnused != null) {
-            addToMapValues(queryParams, "renameKeyIfExistsAndUnused", List.of(String.valueOf(renameKeyIfExistsAndUnused)));
+            queryParams.put("renameKeyIfExistsAndUnused", String.valueOf(renameKeyIfExistsAndUnused));
         }
         if (migrated != null) {
-            addToMapValues(queryParams, "migrated", List.of(String.valueOf(migrated)));
+            queryParams.put("migrated", String.valueOf(migrated));
         }
         if (skipResponse != null) {
-            addToMapValues(queryParams, "skipResponse", List.of(String.valueOf(skipResponse)));
+            queryParams.put("skipResponse", String.valueOf(skipResponse));
         }
         if (callCompletion != null) {
-            addToMapValues(queryParams, "callCompletion", List.of(String.valueOf(callCompletion)));
+            queryParams.put("callCompletion", String.valueOf(callCompletion));
         }
         if (callTimeoutSec != null) {
-            addToMapValues(queryParams, "callTimeoutSec", List.of(String.valueOf(callTimeoutSec)));
+            queryParams.put("callTimeoutSec", String.valueOf(callTimeoutSec));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -565,18 +549,18 @@ public class SubscriptionApi {
 
 
     public void deleteSubscriptionCustomFields(final UUID subscriptionId, final List<UUID> customField, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling deleteSubscriptionCustomFields");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling deleteSubscriptionCustomFields");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/customFields"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (customField != null) {
-            addToMapValues(queryParams, "customField", Converter.convertUUIDListToStringList(customField));
+            queryParams.putAll("customField", Converter.convertUUIDListToStringList(customField));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -586,18 +570,18 @@ public class SubscriptionApi {
 
 
     public void deleteSubscriptionTags(final UUID subscriptionId, final List<UUID> tagDef, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling deleteSubscriptionTags");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling deleteSubscriptionTags");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/tags"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (tagDef != null) {
-            addToMapValues(queryParams, "tagDef", Converter.convertUUIDListToStringList(tagDef));
+            queryParams.putAll("tagDef", Converter.convertUUIDListToStringList(tagDef));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -610,18 +594,18 @@ public class SubscriptionApi {
     }
 
     public Subscription getSubscription(final UUID subscriptionId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscription");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscription");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -629,7 +613,7 @@ public class SubscriptionApi {
     }
 
     public AuditLogs getSubscriptionAuditLogsWithHistory(final UUID subscriptionId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscriptionAuditLogsWithHistory");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscriptionAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/auditLogsWithHistory"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
@@ -647,20 +631,20 @@ public class SubscriptionApi {
     }
 
     public Subscription getSubscriptionByKey(final String externalKey, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getSubscriptionByKey");
+        Preconditions.checkNotNull(externalKey, "Missing the required parameter 'externalKey' when calling getSubscriptionByKey");
 
         final String uri = "/1.0/kb/subscriptions";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (externalKey != null) {
-            addToMapValues(queryParams, "externalKey", List.of(String.valueOf(externalKey)));
+            queryParams.put("externalKey", String.valueOf(externalKey));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -672,18 +656,18 @@ public class SubscriptionApi {
     }
 
     public CustomFields getSubscriptionCustomFields(final UUID subscriptionId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscriptionCustomFields");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscriptionCustomFields");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/customFields"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -691,7 +675,7 @@ public class SubscriptionApi {
     }
 
     public AuditLogs getSubscriptionEventAuditLogsWithHistory(final UUID eventId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(eventId, "Missing the required parameter 'eventId' when calling getSubscriptionEventAuditLogsWithHistory");
+        Preconditions.checkNotNull(eventId, "Missing the required parameter 'eventId' when calling getSubscriptionEventAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/subscriptions/events/{eventId}/auditLogsWithHistory"
           .replaceAll("\\{" + "eventId" + "\\}", eventId.toString());
@@ -709,21 +693,21 @@ public class SubscriptionApi {
     }
 
     public Tags getSubscriptionTags(final UUID subscriptionId, final Boolean includedDeleted, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscriptionTags");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getSubscriptionTags");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/tags"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (includedDeleted != null) {
-            addToMapValues(queryParams, "includedDeleted", List.of(String.valueOf(includedDeleted)));
+            queryParams.put("includedDeleted", String.valueOf(includedDeleted));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -731,8 +715,8 @@ public class SubscriptionApi {
     }
 
     public void modifySubscriptionCustomFields(final UUID subscriptionId, final CustomFields body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling modifySubscriptionCustomFields");
-        checkNotNull(body, "Missing the required parameter 'body' when calling modifySubscriptionCustomFields");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling modifySubscriptionCustomFields");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling modifySubscriptionCustomFields");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/customFields"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
@@ -747,18 +731,18 @@ public class SubscriptionApi {
     }
 
     public void uncancelSubscriptionPlan(final UUID subscriptionId, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling uncancelSubscriptionPlan");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling uncancelSubscriptionPlan");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/uncancel"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -766,18 +750,18 @@ public class SubscriptionApi {
     }
 
     public void undoChangeSubscriptionPlan(final UUID subscriptionId, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling undoChangeSubscriptionPlan");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling undoChangeSubscriptionPlan");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/undoChangePlan"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -789,22 +773,22 @@ public class SubscriptionApi {
     }
 
     public void updateSubscriptionBCD(final UUID subscriptionId, final Subscription body, final LocalDate effectiveFromDate, final Boolean forceNewBcdWithPastEffectiveDate, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling updateSubscriptionBCD");
-        checkNotNull(body, "Missing the required parameter 'body' when calling updateSubscriptionBCD");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling updateSubscriptionBCD");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling updateSubscriptionBCD");
 
         final String uri = "/1.0/kb/subscriptions/{subscriptionId}/bcd"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (effectiveFromDate != null) {
-            addToMapValues(queryParams, "effectiveFromDate", List.of(String.valueOf(effectiveFromDate)));
+            queryParams.put("effectiveFromDate", String.valueOf(effectiveFromDate));
         }
         if (forceNewBcdWithPastEffectiveDate != null) {
-            addToMapValues(queryParams, "forceNewBcdWithPastEffectiveDate", List.of(String.valueOf(forceNewBcdWithPastEffectiveDate)));
+            queryParams.put("forceNewBcdWithPastEffectiveDate", String.valueOf(forceNewBcdWithPastEffectiveDate));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();

--- a/src/main/java/org/killbill/billing/client/api/gen/TagApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/TagApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -40,6 +36,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -59,23 +58,8 @@ public class TagApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public AuditLogs getTagAuditLogsWithHistory(final UUID tagId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(tagId, "Missing the required parameter 'tagId' when calling getTagAuditLogsWithHistory");
+        Preconditions.checkNotNull(tagId, "Missing the required parameter 'tagId' when calling getTagAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/tags/{tagId}/auditLogsWithHistory"
           .replaceAll("\\{" + "tagId" + "\\}", tagId.toString());
@@ -96,19 +80,19 @@ public class TagApi {
 
         final String uri = "/1.0/kb/tags/pagination";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -120,24 +104,24 @@ public class TagApi {
     }
 
     public Tags searchTags(final String searchKey, final Long offset, final Long limit, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchTags");
+        Preconditions.checkNotNull(searchKey, "Missing the required parameter 'searchKey' when calling searchTags");
 
         final String uri = "/1.0/kb/tags/search/{searchKey}"
           .replaceAll("\\{" + "searchKey" + "\\}", searchKey.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (offset != null) {
-            addToMapValues(queryParams, "offset", List.of(String.valueOf(offset)));
+            queryParams.put("offset", String.valueOf(offset));
         }
         if (limit != null) {
-            addToMapValues(queryParams, "limit", List.of(String.valueOf(limit)));
+            queryParams.put("limit", String.valueOf(limit));
         }
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 

--- a/src/main/java/org/killbill/billing/client/api/gen/TagDefinitionApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/TagDefinitionApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.AuditLog;
@@ -40,6 +36,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -59,23 +58,8 @@ public class TagDefinitionApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public TagDefinition createTagDefinition(final TagDefinition body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createTagDefinition");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createTagDefinition");
 
         final String uri = "/1.0/kb/tagDefinitions";
 
@@ -92,7 +76,7 @@ public class TagDefinitionApi {
 
 
     public void deleteTagDefinition(final UUID tagDefinitionId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(tagDefinitionId, "Missing the required parameter 'tagDefinitionId' when calling deleteTagDefinition");
+        Preconditions.checkNotNull(tagDefinitionId, "Missing the required parameter 'tagDefinitionId' when calling deleteTagDefinition");
 
         final String uri = "/1.0/kb/tagDefinitions/{tagDefinitionId}"
           .replaceAll("\\{" + "tagDefinitionId" + "\\}", tagDefinitionId.toString());
@@ -110,18 +94,18 @@ public class TagDefinitionApi {
     }
 
     public TagDefinition getTagDefinition(final UUID tagDefinitionId, final AuditLevel audit, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(tagDefinitionId, "Missing the required parameter 'tagDefinitionId' when calling getTagDefinition");
+        Preconditions.checkNotNull(tagDefinitionId, "Missing the required parameter 'tagDefinitionId' when calling getTagDefinition");
 
         final String uri = "/1.0/kb/tagDefinitions/{tagDefinitionId}"
           .replaceAll("\\{" + "tagDefinitionId" + "\\}", tagDefinitionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -129,7 +113,7 @@ public class TagDefinitionApi {
     }
 
     public AuditLogs getTagDefinitionAuditLogsWithHistory(final UUID tagDefinitionId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(tagDefinitionId, "Missing the required parameter 'tagDefinitionId' when calling getTagDefinitionAuditLogsWithHistory");
+        Preconditions.checkNotNull(tagDefinitionId, "Missing the required parameter 'tagDefinitionId' when calling getTagDefinitionAuditLogsWithHistory");
 
         final String uri = "/1.0/kb/tagDefinitions/{tagDefinitionId}/auditLogsWithHistory"
           .replaceAll("\\{" + "tagDefinitionId" + "\\}", tagDefinitionId.toString());
@@ -150,13 +134,13 @@ public class TagDefinitionApi {
 
         final String uri = "/1.0/kb/tagDefinitions";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (audit != null) {
-            addToMapValues(queryParams, "audit", List.of(String.valueOf(audit)));
+            queryParams.put("audit", String.valueOf(audit));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 

--- a/src/main/java/org/killbill/billing/client/api/gen/TenantApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/TenantApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.killbill.billing.client.model.gen.Tenant;
@@ -38,6 +34,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -57,39 +56,24 @@ public class TenantApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public Tenant createTenant(final Tenant body, final RequestOptions inputOptions) throws KillBillClientException {
         return createTenant(body, Boolean.valueOf(false), inputOptions);
     }
 
     public Tenant createTenant(final Tenant body, final Boolean useGlobalDefault, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling createTenant");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling createTenant");
 
         final String uri = "/1.0/kb/tenants";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (useGlobalDefault != null) {
-            addToMapValues(queryParams, "useGlobalDefault", List.of(String.valueOf(useGlobalDefault)));
+            queryParams.put("useGlobalDefault", String.valueOf(useGlobalDefault));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -111,7 +95,7 @@ public class TenantApi {
 
 
     public void deletePluginConfiguration(final String pluginName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling deletePluginConfiguration");
+        Preconditions.checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling deletePluginConfiguration");
 
         final String uri = "/1.0/kb/tenants/uploadPluginConfig/{pluginName}"
           .replaceAll("\\{" + "pluginName" + "\\}", pluginName.toString());
@@ -125,7 +109,7 @@ public class TenantApi {
 
 
     public void deletePluginPaymentStateMachineConfig(final String pluginName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling deletePluginPaymentStateMachineConfig");
+        Preconditions.checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling deletePluginPaymentStateMachineConfig");
 
         final String uri = "/1.0/kb/tenants/uploadPluginPaymentStateMachineConfig/{pluginName}"
           .replaceAll("\\{" + "pluginName" + "\\}", pluginName.toString());
@@ -151,7 +135,7 @@ public class TenantApi {
 
 
     public void deleteUserKeyValue(final String keyName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(keyName, "Missing the required parameter 'keyName' when calling deleteUserKeyValue");
+        Preconditions.checkNotNull(keyName, "Missing the required parameter 'keyName' when calling deleteUserKeyValue");
 
         final String uri = "/1.0/kb/tenants/userKeyValue/{keyName}"
           .replaceAll("\\{" + "keyName" + "\\}", keyName.toString());
@@ -164,7 +148,7 @@ public class TenantApi {
     }
 
     public TenantKeyValues getAllPluginConfiguration(final String keyPrefix, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(keyPrefix, "Missing the required parameter 'keyPrefix' when calling getAllPluginConfiguration");
+        Preconditions.checkNotNull(keyPrefix, "Missing the required parameter 'keyPrefix' when calling getAllPluginConfiguration");
 
         final String uri = "/1.0/kb/tenants/uploadPerTenantConfig/{keyPrefix}/search"
           .replaceAll("\\{" + "keyPrefix" + "\\}", keyPrefix.toString());
@@ -190,7 +174,7 @@ public class TenantApi {
     }
 
     public TenantKeyValue getPluginConfiguration(final String pluginName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling getPluginConfiguration");
+        Preconditions.checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling getPluginConfiguration");
 
         final String uri = "/1.0/kb/tenants/uploadPluginConfig/{pluginName}"
           .replaceAll("\\{" + "pluginName" + "\\}", pluginName.toString());
@@ -204,7 +188,7 @@ public class TenantApi {
     }
 
     public TenantKeyValue getPluginPaymentStateMachineConfig(final String pluginName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling getPluginPaymentStateMachineConfig");
+        Preconditions.checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling getPluginPaymentStateMachineConfig");
 
         final String uri = "/1.0/kb/tenants/uploadPluginPaymentStateMachineConfig/{pluginName}"
           .replaceAll("\\{" + "pluginName" + "\\}", pluginName.toString());
@@ -230,7 +214,7 @@ public class TenantApi {
     }
 
     public Tenant getTenant(final UUID tenantId, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(tenantId, "Missing the required parameter 'tenantId' when calling getTenant");
+        Preconditions.checkNotNull(tenantId, "Missing the required parameter 'tenantId' when calling getTenant");
 
         final String uri = "/1.0/kb/tenants/{tenantId}"
           .replaceAll("\\{" + "tenantId" + "\\}", tenantId.toString());
@@ -247,13 +231,13 @@ public class TenantApi {
 
         final String uri = "/1.0/kb/tenants";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (apiKey != null) {
-            addToMapValues(queryParams, "apiKey", List.of(String.valueOf(apiKey)));
+            queryParams.put("apiKey", String.valueOf(apiKey));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -261,7 +245,7 @@ public class TenantApi {
     }
 
     public TenantKeyValue getUserKeyValue(final String keyName, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(keyName, "Missing the required parameter 'keyName' when calling getUserKeyValue");
+        Preconditions.checkNotNull(keyName, "Missing the required parameter 'keyName' when calling getUserKeyValue");
 
         final String uri = "/1.0/kb/tenants/userKeyValue/{keyName}"
           .replaceAll("\\{" + "keyName" + "\\}", keyName.toString());
@@ -275,8 +259,8 @@ public class TenantApi {
     }
 
     public TenantKeyValue insertUserKeyValue(final String keyName, final String body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(keyName, "Missing the required parameter 'keyName' when calling insertUserKeyValue");
-        checkNotNull(body, "Missing the required parameter 'body' when calling insertUserKeyValue");
+        Preconditions.checkNotNull(keyName, "Missing the required parameter 'keyName' when calling insertUserKeyValue");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling insertUserKeyValue");
 
         final String uri = "/1.0/kb/tenants/userKeyValue/{keyName}"
           .replaceAll("\\{" + "keyName" + "\\}", keyName.toString());
@@ -296,15 +280,15 @@ public class TenantApi {
 
         final String uri = "/1.0/kb/tenants/registerNotificationCallback";
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (cb != null) {
-            addToMapValues(queryParams, "cb", List.of(String.valueOf(cb)));
+            queryParams.put("cb", String.valueOf(cb));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
         final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_CONTENT_TYPE, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
@@ -313,7 +297,7 @@ public class TenantApi {
     }
 
     public TenantKeyValue uploadPerTenantConfiguration(final String body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadPerTenantConfiguration");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadPerTenantConfiguration");
 
         final String uri = "/1.0/kb/tenants/uploadPerTenantConfig";
 
@@ -329,8 +313,8 @@ public class TenantApi {
     }
 
     public TenantKeyValue uploadPluginConfiguration(final String pluginName, final String body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling uploadPluginConfiguration");
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadPluginConfiguration");
+        Preconditions.checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling uploadPluginConfiguration");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadPluginConfiguration");
 
         final String uri = "/1.0/kb/tenants/uploadPluginConfig/{pluginName}"
           .replaceAll("\\{" + "pluginName" + "\\}", pluginName.toString());
@@ -347,8 +331,8 @@ public class TenantApi {
     }
 
     public TenantKeyValue uploadPluginPaymentStateMachineConfig(final String pluginName, final String body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling uploadPluginPaymentStateMachineConfig");
-        checkNotNull(body, "Missing the required parameter 'body' when calling uploadPluginPaymentStateMachineConfig");
+        Preconditions.checkNotNull(pluginName, "Missing the required parameter 'pluginName' when calling uploadPluginPaymentStateMachineConfig");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling uploadPluginPaymentStateMachineConfig");
 
         final String uri = "/1.0/kb/tenants/uploadPluginPaymentStateMachineConfig/{pluginName}"
           .replaceAll("\\{" + "pluginName" + "\\}", pluginName.toString());

--- a/src/main/java/org/killbill/billing/client/api/gen/UsageApi.java
+++ b/src/main/java/org/killbill/billing/client/api/gen/UsageApi.java
@@ -20,10 +20,6 @@
 
 package org.killbill.billing.client.api.gen;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 
 import org.joda.time.LocalDate;
@@ -38,6 +34,9 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
+import org.killbill.billing.client.util.Preconditions;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
 
 /**
  *           DO NOT EDIT !!!
@@ -57,40 +56,25 @@ public class UsageApi {
         this.httpClient = httpClient;
     }
 
-    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
-        if (map.containsKey(key)) {
-            map.get(key).addAll(values);
-        } else {
-            map.put(key, values);
-        }
-    }
-
-    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
-        if (reference == null) {
-            throw new NullPointerException(String.valueOf(errorMessage));
-        }
-        return reference;
-    }
-
     public RolledUpUsage getAllUsage(final UUID subscriptionId, final LocalDate startDate, final LocalDate endDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getAllUsage");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getAllUsage");
 
         final String uri = "/1.0/kb/usages/{subscriptionId}"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (startDate != null) {
-            addToMapValues(queryParams, "startDate", List.of(String.valueOf(startDate)));
+            queryParams.put("startDate", String.valueOf(startDate));
         }
         if (endDate != null) {
-            addToMapValues(queryParams, "endDate", List.of(String.valueOf(endDate)));
+            queryParams.put("endDate", String.valueOf(endDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -98,26 +82,26 @@ public class UsageApi {
     }
 
     public RolledUpUsage getUsage(final UUID subscriptionId, final String unitType, final LocalDate startDate, final LocalDate endDate, final Map<String, String> pluginProperty, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getUsage");
-        checkNotNull(unitType, "Missing the required parameter 'unitType' when calling getUsage");
+        Preconditions.checkNotNull(subscriptionId, "Missing the required parameter 'subscriptionId' when calling getUsage");
+        Preconditions.checkNotNull(unitType, "Missing the required parameter 'unitType' when calling getUsage");
 
         final String uri = "/1.0/kb/usages/{subscriptionId}/{unitType}"
           .replaceAll("\\{" + "subscriptionId" + "\\}", subscriptionId.toString())
           .replaceAll("\\{" + "unitType" + "\\}", unitType.toString());
 
-        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>(inputOptions.getQueryParams());
         if (startDate != null) {
-            addToMapValues(queryParams, "startDate", List.of(String.valueOf(startDate)));
+            queryParams.put("startDate", String.valueOf(startDate));
         }
         if (endDate != null) {
-            addToMapValues(queryParams, "endDate", List.of(String.valueOf(endDate)));
+            queryParams.put("endDate", String.valueOf(endDate));
         }
         if (pluginProperty != null) {
-            addToMapValues(queryParams, "pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
+            queryParams.putAll("pluginProperty", Converter.convertPluginPropertyMap(pluginProperty));
         }
 
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        inputOptionsBuilder.withQueryParams(queryParams);
+        inputOptionsBuilder.withQueryParams(queryParams.asMap());
         inputOptionsBuilder.withHeader(KillBillHttpClient.HTTP_HEADER_ACCEPT, "application/json");
         final RequestOptions requestOptions = inputOptionsBuilder.build();
 
@@ -125,7 +109,7 @@ public class UsageApi {
     }
 
     public void recordUsage(final SubscriptionUsageRecord body, final RequestOptions inputOptions) throws KillBillClientException {
-        checkNotNull(body, "Missing the required parameter 'body' when calling recordUsage");
+        Preconditions.checkNotNull(body, "Missing the required parameter 'body' when calling recordUsage");
 
         final String uri = "/1.0/kb/usages";
 

--- a/src/main/java/org/killbill/billing/client/util/Multimap.java
+++ b/src/main/java/org/killbill/billing/client/util/Multimap.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client.util;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Subset of Guava's {@code Multimap}.
+ */
+public interface Multimap<K, V> {
+
+    void put(K key, V value);
+
+    void putAll(K key, Collection<V> values);
+
+    void remove(K key);
+
+    Map<K, Collection<V>> asMap();
+}

--- a/src/main/java/org/killbill/billing/client/util/Preconditions.java
+++ b/src/main/java/org/killbill/billing/client/util/Preconditions.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client.util;
+
+public final class Preconditions {
+
+    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
+        if (reference == null) {
+            throw new NullPointerException(String.valueOf(errorMessage));
+        }
+        return reference;
+    }
+}

--- a/src/main/java/org/killbill/billing/client/util/TreeMapSetMultimap.java
+++ b/src/main/java/org/killbill/billing/client/util/TreeMapSetMultimap.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client.util;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * <p>Implementation of {@link Multimap}: </p>
+ * <ul>
+ *     <li>backed by {@link SortedMap} and use {@link TreeSet} as a values</li>
+ *     <li>key cannot be {@code null}</li>
+ *     <li>values cannot be {@code null}</li>
+ *     <li>{@link #asMap()} return backed map (the {@code SortedMap}).</li>
+ * </ul>
+ */
+public class TreeMapSetMultimap<K, V> implements Multimap<K, V> {
+
+    private final SortedMap<K, Collection<V>> delegate = new TreeMap<>();
+
+    public TreeMapSetMultimap() {
+    }
+
+    public TreeMapSetMultimap(final Map<K, ? extends Collection<V>> map) {
+        if (map != null && !map.isEmpty()) {
+            delegate.putAll(map);
+        }
+    }
+
+    @Override
+    public void put(final K key, final V value) {
+        Preconditions.checkNotNull(key, "Cannot #put() with null key");
+        Preconditions.checkNotNull(value, "Cannot #put() with null value");
+
+        if (delegate.containsKey(key)) {
+            delegate.get(key).add(value);
+        } else {
+            final Collection<V> list = new TreeSet<>();
+            list.add(value);
+            delegate.put(key, list);
+        }
+    }
+
+    @Override
+    public void putAll(final K key, final Collection<V> values) {
+        Preconditions.checkNotNull(key, "Cannot #putAll() with null key");
+        Preconditions.checkNotNull(values, "Cannot #putAll() with null values");
+
+        if (!values.isEmpty()) {
+            if (delegate.containsKey(key)) {
+                delegate.get(key).addAll(values);
+            } else {
+                delegate.put(key, new TreeSet<>(values));
+            }
+        }
+    }
+
+    @Override
+    public void remove(final K key) {
+        Preconditions.checkNotNull(key, "Cannot #remove() with null key");
+        delegate.remove(key);
+    }
+
+    @Override
+    public Map<K, Collection<V>> asMap() {
+        return delegate;
+    }
+
+    @Override
+    public String toString() {
+        return "TreeMapSetMultimap {"  + delegate + '}';
+    }
+}

--- a/src/test/java/org/killbill/billing/client/TestRequestOptions.java
+++ b/src/test/java/org/killbill/billing/client/TestRequestOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestRequestOptions {
+
+    @Test(groups = "fast")
+    public void test() {
+        // requestOptionsWithImmutableMapValues();
+        requestOptionsWithMutableMapValues();
+    }
+
+    void requestOptionsWithImmutableMapValues() {
+        // Let's consider scenario a user using the java client:
+        final Map<String, Collection<String>> queryParams = new HashMap<>();
+        // User can generously do this ...
+        queryParams.put("key1", new ArrayList<>(List.of("1.1", "1.2", "1.3")));
+        // .... or accidentally do this (because after guava removed, this is the "straight forward" approach)
+        queryParams.put("key2", List.of("2.1", "2.2", "2.3"));
+        // So far, good.
+        final RequestOptions requestOptions = new RequestOptionsBuilder()
+                .withQueryParams(queryParams)
+                .build();
+
+        // .... Then our internal generated API classes have something like this: (eg: InvoiceApi)
+        // (Also note that as per '34b59c4c' commit, InvoiceApi still use internal #addToMapValues() method, which is do the same thing)
+        final Multimap<String, String> queryParamsInApi = new TreeMapSetMultimap<>(requestOptions.getQueryParams());
+
+        // This one Ok, because user pass mutable object (wrap List.of() to new ArrayList)
+        queryParamsInApi.put("key1", "1.4");
+        try {
+            // This one not Ok, because user pass immutable object first (only use List.of() )
+            queryParamsInApi.put("key2", "2.4");
+            Assert.fail("Make sure that RequestOptionBuilder#withQueryParams NOT calling toMutableMapValues() method");
+        } catch (final UnsupportedOperationException ignored) {
+        }
+    }
+
+    // Simulating the same thing as "requestOptionsWithImmutableMapValues()", but expect that
+    // RequestOptions#withQueryParams() call Req method.
+
+    /**
+     * Simulating the same thing as {@link #requestOptionsWithImmutableMapValues()}, but expect that
+     */
+    private void requestOptionsWithMutableMapValues() {
+        final Map<String, Collection<String>> queryParams = new HashMap<>();
+        queryParams.put("key1", new ArrayList<>(List.of("1.1", "1.2", "1.3")));
+        queryParams.put("key2", List.of("2.1", "2.2", "2.3"));
+
+        final RequestOptions requestOptions = new RequestOptionsBuilder()
+                .withQueryParams(queryParams)
+                .build();
+
+        final Multimap<String, String> queryParamsInApi = new TreeMapSetMultimap<>(requestOptions.getQueryParams());
+
+        queryParamsInApi.put("key1", "1.4");
+        queryParamsInApi.put("key2", "2.4");
+    }
+}

--- a/src/test/java/org/killbill/billing/client/api/gen/TestInvoiceApi.java
+++ b/src/test/java/org/killbill/billing/client/api/gen/TestInvoiceApi.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client.api.gen;
+
+import java.util.UUID;
+
+import org.killbill.billing.client.KillBillClientException;
+import org.killbill.billing.client.KillBillHttpClient;
+import org.killbill.billing.client.RequestOptions;
+import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
+import org.killbill.billing.client.util.Multimap;
+import org.killbill.billing.client.util.TreeMapSetMultimap;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class TestInvoiceApi {
+
+    // make sure that withQueryParams() will not throw the same problem as before
+    // adding RequestOptionsBuilder#toMutableMapValues()
+    @Test(groups = "fast")
+    public void getPaymentsForInvoice() throws KillBillClientException {
+        final KillBillHttpClient httpClient = Mockito.mock(KillBillHttpClient.class);
+
+        final Multimap<String, String> queryParams = new TreeMapSetMultimap<>();
+        queryParams.put("key1", "value1");
+
+        final RequestOptions requestOptions = new RequestOptionsBuilder()
+                .withQueryParams(queryParams.asMap())
+                .build();
+
+        final InvoiceApi api = new InvoiceApi(httpClient);
+        api.getPaymentsForInvoice(UUID.randomUUID(), requestOptions);
+
+        Mockito.verify(httpClient, Mockito.times(1)).doGet(Mockito.anyString(), (Class<?>) Mockito.any(), Mockito.any());
+    }
+}

--- a/src/test/java/org/killbill/billing/client/util/TestTreeMapSetMultimap.java
+++ b/src/test/java/org/killbill/billing/client/util/TestTreeMapSetMultimap.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.client.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestTreeMapSetMultimap {
+
+    @Test(groups = "fast")
+    public void put() {
+        final Multimap<String, String> multimap = new TreeMapSetMultimap<>();
+        multimap.put("key", "value");
+        Assert.assertEquals(multimap.asMap().size(), 1);
+        Assert.assertTrue(multimap.asMap().keySet().stream().allMatch("key"::equals));
+        Assert.assertTrue(multimap.asMap().values().stream().allMatch(values -> values.contains("value")));
+
+        try {
+            multimap.put(null, "any");
+            Assert.fail("Null key should not supported");
+        } catch (final NullPointerException ignored) {
+        }
+
+        try {
+            multimap.put(null, "any");
+            Assert.fail("Null values should not supported");
+        } catch (final NullPointerException ignored) {
+        }
+    }
+
+    @Test(groups = "fast")
+    public void putAll() {
+        final Multimap<String, String> multimap = new TreeMapSetMultimap<>();
+        multimap.putAll("key1", List.of("1.1", "1.2", "1.3"));
+
+        Assert.assertTrue(multimap.asMap().keySet().stream().allMatch("key1"::equals));
+        Assert.assertTrue(multimap.asMap().values().stream().allMatch(values -> values.containsAll(List.of("1.1", "1.2", "1.3"))));
+
+        // No matter what user supplied in values, it should be able to put more.
+        multimap.put("key1", "1.4");
+        multimap.putAll("key1", Collections.singleton("1.5"));
+        multimap.putAll("key1", Set.of("1.5", "1.6")); // 1.5 purposely duplicated.
+        multimap.putAll("key2", List.of("2.1", "2.2"));
+        multimap.putAll("key1", Collections.emptyList());
+
+        Assert.assertEquals(multimap.asMap().get("key1").size(), 6);
+        Assert.assertTrue(multimap.asMap().get("key1").containsAll(List.of("1.1", "1.2", "1.3", "1.4", "1.5", "1.6")));
+    }
+
+    @Test
+    public void remove() {
+        final Multimap<String, String> multimap = new TreeMapSetMultimap<>();
+        multimap.put("key1", "val1");
+        multimap.put("key2", "val2");
+
+        Assert.assertEquals(multimap.asMap().size(), 2);
+
+        multimap.remove("key1");
+
+        Assert.assertEquals(multimap.asMap().size(), 1);
+    }
+
+    @Test(groups = "fast")
+    public void asMap() {
+        final Multimap<String, String> multimap = new TreeMapSetMultimap<>();
+        multimap.putAll("key1", List.of("1.1", "1.2", "1.3"));
+
+        final Map<String, Collection<String>> asMap = multimap.asMap();
+
+        Assert.assertEquals(asMap.size(), 1);
+        Assert.assertEquals(asMap.get("key1").size(), 3);
+
+        multimap.put("key1", "1.4");
+        multimap.putAll("key1", List.of("1.5", "1.6"));
+        multimap.put("key2", "2.1");
+
+        Assert.assertEquals(asMap.get("key2"), List.of("2.1"));
+        Assert.assertEquals(asMap.size(), 2);
+        Assert.assertEquals(asMap.get("key1").size(), 6);
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to fix bug that found in several tests in `killbill-profiles` module:

1. First bug, described in [TestRequestOptions](https://github.com/killbill/killbill-client-java/pull/109/files#diff-7b6b31ee65352bcdb448519b6a8b08083eea7655f9f8c356bf7debd4aa4cb2dd). We can : 
   - apply what we currently have in this PR, or
   - in documentation/example, ask user to use mutable collection/list when creating `Map` with `Collection` values in `withQueryParams()` or `withQueryParamsForFollow()`.
   
   I prefer first approach.

2. Second bug, happened in `addToMapValues()` that I added, where passing empty list/collection to multi-value `Map` will cause parameter get truncated. I ended up with remove `addToMapValues()` and use `Multimap` that [added](https://github.com/killbill/killbill-client-java/pull/109/files#diff-a8498b62518e9937d75beaa4eba7397a179c374b77ba42469d136ac5658fee04) in this PR.